### PR TITLE
x86-64 trace fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Change folder to qemu and build tracer with command
 ```bash
 $ ./configure --prefix=$HOME --with-tracewrap=`realpath ../bap-traces` \
 --extra-ldflags=-Lprotobuf --target-list="arm-linux-user i386-linux-user \
-mips-linux-user"
+x86_64-linux-user mips-linux-user"
 $ make -C protobuf
 $ make
 $ make install
@@ -68,6 +68,7 @@ To run executable `exec` and to save the trace data to `exec.trace`, use
 ```bash
 $ qemu-arm -tracefile exec.trace exec # trace ARM target executable
 $ qemu-i386 -tracefile exec.trace exec # trace X86 target executable
+$ qemu-x86_64 -tracefile exec.trace exec # trace X86-64 target executable
 $ qemu-mips -tracefile exec.trace exec # trace MIPS target executable
 ```
 
@@ -76,4 +77,4 @@ Hints: use option -L to set the elf interpreter prefix to 'path'. Use
 to download arm and x86 libraries.
 
 # Notes
-  Only ARM, X86, MIPS targets are supported in this branch.
+  Only ARM, X86, X86-64, MIPS targets are supported in this branch.

--- a/include/tracewrap.h
+++ b/include/tracewrap.h
@@ -15,13 +15,13 @@ struct toc_entry {
 
 extern FILE *qemu_tracefile;
 void qemu_trace(Frame frame);
-void qemu_trace_newframe(uint64_t addr, int tread_id);
+void qemu_trace_newframe(target_ulong addr, int tread_id);
 void qemu_trace_add_operand(OperandInfo *oi, int inout);
-void qemu_trace_endframe(CPUArchState *env, target_ulong pc, size_t size);
+void qemu_trace_endframe(CPUArchState *env, target_ulong pc, target_ulong size);
 void qemu_trace_finish(uint32_t exit_code);
 
-OperandInfo * load_store_reg(uint32_t reg, uint32_t val, int ls);
-OperandInfo * load_store_mem(uint32_t addr, uint32_t val, int ls, int len);
+OperandInfo * load_store_reg(target_ulong reg, target_ulong val, int ls);
+OperandInfo * load_store_mem(target_ulong addr, target_ulong val, int ls, int len);
 
 #define REG_CPSR 64
 #define REG_APSR 65

--- a/linux-user/x86_64/trace_info.h
+++ b/linux-user/x86_64/trace_info.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "arch.h"
+
+const uint64_t bfd_arch = bfd_arch_i386;
+const uint64_t bfd_machine = mach_x86_64;

--- a/target-i386/helper.h
+++ b/target-i386/helper.h
@@ -20,11 +20,11 @@ DEF_HELPER_2(idivq_EAX, void, env, tl)
 
 #ifdef HAS_TRACEWRAP
 DEF_HELPER_1(trace_newframe, void, tl)
-DEF_HELPER_3(trace_endframe, void, env, tl, i32)
-DEF_HELPER_2(trace_load_reg, void, i32, i32)
-DEF_HELPER_2(trace_store_reg, void, i32, i32)
-DEF_HELPER_3(trace_ld, void, env, i32, i32)
-DEF_HELPER_3(trace_st, void, env, i32, i32)
+DEF_HELPER_3(trace_endframe, void, env, tl, tl)
+DEF_HELPER_2(trace_load_reg, void, tl, tl)
+DEF_HELPER_2(trace_store_reg, void, tl, tl)
+DEF_HELPER_3(trace_ld, void, env, tl, tl)
+DEF_HELPER_3(trace_st, void, env, tl, tl)
 DEF_HELPER_1(trace_load_eflags, void, env)
 DEF_HELPER_1(trace_store_eflags, void, env)
 #endif //HAS_TRACEWRAP

--- a/tracewrap.c
+++ b/tracewrap.c
@@ -26,7 +26,7 @@ void do_qemu_set_trace(const char *tracefilename)
         cur_toc_entry = toc;
 }
 
-void qemu_trace_newframe(uint64_t addr, int thread_id)
+void qemu_trace_newframe(target_ulong addr, int thread_id)
 {
     if (open_frame)
     {
@@ -106,7 +106,7 @@ void qemu_trace_add_operand(OperandInfo *oi, int inout)
     ol->elem[ol->n_elem - 1] = oi;
 }
 
-void qemu_trace_endframe(CPUArchState *env, target_ulong pc, size_t size)
+void qemu_trace_endframe(CPUArchState *env, target_ulong pc, target_ulong size)
 {
     if (! open_frame) {
         return;


### PR DESCRIPTION
Changes:
1. added x86-64 register names (target-i386/trace_helper.c)
2. TCGv_i32 replaced with TCGv (target-i386/translate.c)
3. added frame closing inside gen_jmp_im function (target-i386/translate.c)


