### PR TITLE
fixed store in x86 flags register

### DIFF
--- a/include/tracewrap.h
+++ b/include/tracewrap.h
@@ -43,6 +43,9 @@ void qemu_trace_finish(uint32_t exit_code);
 OperandInfo * load_store_reg(target_ulong reg, target_ulong val, int ls);
 OperandInfo * load_store_mem(target_ulong addr, target_ulong val, int ls, int len);
 
+void *state(void);
+void set_state(void *state);
+
 #define REG_EFLAGS 66
 #define REG_LO 33
 #define REG_HI 34

--- a/target-i386/trace_helper_x86.h
+++ b/target-i386/trace_helper_x86.h
@@ -1,0 +1,18 @@
+#ifndef TRACE_HELPER_X86
+#define TRACE_HELPER_X86
+
+#include "cpu.h"
+#include "helper.h"
+#include "tracewrap.h"
+#include "qemu/log.h"
+
+#define x86_flags_t target_ulong
+
+OperandInfo * store_flag(short val, const char *reg_name);
+bool is_flag_changed(x86_flags_t old_flags, x86_flags_t flags, x86_flags_t mask);
+short flag_value(x86_flags_t flags, x86_flags_t mask);
+void store_if_changed(x86_flags_t old_flags, x86_flags_t flags, x86_flags_t mask, const char *reg_name);
+void set_x86_flags(x86_flags_t state);
+x86_flags_t x86_flags(void);
+
+#endif // TRACE_HELPER_X86

--- a/tracewrap.c
+++ b/tracewrap.c
@@ -32,6 +32,11 @@ static uint64_t toc_num_frames = 0;
 static guchar target_md5[MD5LEN];
 static char target_path[PATH_MAX] = "unknown";
 
+static void *target_state;
+
+void *state(void)  { return target_state; }   
+void set_state(void *state) { target_state = state; }
+
 
 #define WRITE(x) do {                                   \
         if (!file)                                      \


### PR DESCRIPTION
now it's posible to track store in CF, OF, ZF and SF bits of flag register.
Algorithm works in next way. Two steps should be performed to understand what flag bits were changed. First step: necessary to compare previous flag register value with currently computed. If this value not equal then some bits in flag register were changed. Second step: necessary to check all bits, that are interested for us. `flags_value &  bit_mask` - for current bit value, defined with `bit_mask`. So if previous bit value is not equal to present, then bit was changed. The only thing is left to do is to find out this current bit value:  `current_flags & bit_mask`.
