### PR TITLE
adds -tracewrap suffix to version and uses QEMU_FULL_VERSION in trace

### DIFF
--- a/scripts/qemu-version.sh
+++ b/scripts/qemu-version.sh
@@ -4,7 +4,7 @@ set -eu
 
 dir="$1"
 pkgversion="$2"
-version="$3"
+version="$3-tracewrap"
 
 if [ -z "$pkgversion" ]; then
     cd "$dir"

--- a/tracewrap.c
+++ b/tracewrap.c
@@ -5,6 +5,7 @@
 #include <glib.h>
 #include <err.h>
 #include "qemu/log.h"
+#include "qemu-version.h"
 
 #include <sys/types.h>
 #include <unistd.h>
@@ -15,7 +16,7 @@
 
 
 char tracer_name[] = "qemu";
-char tracer_version[] = "2.0.0/tracewrap";
+char tracer_version[] = QEMU_FULL_VERSION;
 
 static Frame * g_frame;
 static uint64_t frames_per_toc_entry = 64LL;


### PR DESCRIPTION
In `--version`:
```
florian@florian-desktop ~/dev/qemu $ ~/bin/prefix/qemu-bap/bin/qemu-arm --version
qemu-arm version 6.2.0-tracewrap (v6.2.0-6-gd32ad4e8b3)
Copyright (c) 2003-2021 Fabrice Bellard and the QEMU Project developers
```

In the trace:
```
florian@florian-desktop ~/dev/emulateme/builds $ rz-tracetest -d -c 0 emulateme.arm32.frames


META:
tracer {
  ...
  version: "6.2.0-tracewrap (v6.2.0-6-gd32ad4e8b3)"
}
```