### PR TITLE
store t32/a32 mode when tracing arm

### DIFF
--- a/include/trace_consts.h
+++ b/include/trace_consts.h
@@ -10,4 +10,4 @@ const uint64_t bfd_machine_offset = 24LL;
 const uint64_t num_trace_frames_offset = 32LL;
 const uint64_t toc_offset_offset = 40LL;
 const uint64_t first_frame_offset = 48LL;
-const uint64_t out_trace_version = 2LL;
+const uint64_t out_trace_version = 3LL;

--- a/include/tracewrap.h
+++ b/include/tracewrap.h
@@ -9,7 +9,6 @@
 
 #include "frame.piqi.pb-c.h"
 
-
 /** initializes trace subsystem.
 
     All pointers are owned by the caller.
@@ -39,6 +38,7 @@ void qemu_trace_init(const char *filename, const char *targetname,
                      char **target_envp);
 void qemu_trace_newframe(target_ulong addr, int tread_id);
 void qemu_trace_add_operand(OperandInfo *oi, int inout);
+void qemu_trace_set_mode(const char *mode_str);
 void qemu_trace_endframe(CPUArchState *env, target_ulong pc, target_ulong size);
 void qemu_trace_finish(uint32_t exit_code);
 

--- a/target/arm/helper.h
+++ b/target/arm/helper.h
@@ -73,6 +73,7 @@ DEF_HELPER_3(trace_cpsr_write, void, env, i32, i32)
 DEF_HELPER_1(trace_cpsr_read, i32, env)
 DEF_HELPER_1(log_read_cpsr, void, env)
 DEF_HELPER_1(log_store_cpsr, void, env)
+DEF_HELPER_1(trace_mode, void, ptr)
 #endif //HAS_TRACEWRAP
 
 DEF_HELPER_3(v7m_msr, void, env, i32, i32)

--- a/target/arm/trace_helper.c
+++ b/target/arm/trace_helper.c
@@ -260,3 +260,7 @@ void HELPER(trace_st64)(CPUARMState *env, uint64_t val, uint32_t addr, uint32_t 
     OperandInfo *oi = load_store_mem(addr, 1, &val, len);
     qemu_trace_add_operand(oi, 0x2);
 }
+
+void HELPER(trace_mode)(void *mode) {
+    qemu_trace_set_mode(mode);
+}

--- a/target/arm/translate.c
+++ b/target/arm/translate.c
@@ -67,6 +67,7 @@ static const char * const regnames[] =
 
 
 #ifdef HAS_TRACEWRAP
+#include <frame_arch.h>
 /* Set to 1 if cpsr contents have already been written for the current instruction. */
 static int loaded_cpsr = 0;
 /* Set to 1 if an instruction affects cpsr. */
@@ -2672,6 +2673,9 @@ static inline void gen_trace_newframe(DisasContext *s)
     TCGv t = tcg_const_i32(s->pc_curr);
     gen_helper_trace_newframe(t);
     tcg_temp_free(t);
+    TCGv_ptr mt = tcg_const_ptr(s->thumb ? FRAME_MODE_ARM_T32 : FRAME_MODE_ARM_A32);
+    gen_helper_trace_mode(mt);
+    tcg_temp_free_ptr(mt);
     trace_instr_state_reset();
 }
 

--- a/tracewrap.c
+++ b/tracewrap.c
@@ -317,6 +317,13 @@ void qemu_trace_add_operand(OperandInfo *oi, int inout) {
     ol->elem[ol->n_elem - 1] = oi;
 }
 
+void qemu_trace_set_mode(const char *mode_str) {
+    if (!open_frame) {
+        return;
+    }
+    g_frame->std_frame->mode = (char *)mode_str;
+}
+
 void qemu_trace_endframe(CPUArchState *env, target_ulong pc, target_ulong size) {
     int i = 0;
     StdFrame *sframe = g_frame->std_frame;


### PR DESCRIPTION
Depends on https://github.com/BinaryAnalysisPlatform/bap-frames/pull/17

This stores, for each frame, the information whether thumb mode is
used, so tools reading the traces will be able to select the right
disassembler to use for each individual instruction when interworking
code is traced.