### PR TITLE
Ask for the absolute path to bap-frames.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ $ git clone git@github.com:BinaryAnalysisPlatform/qemu.git
 Change folder to qemu and build tracer:
 ```bash
 $ cd qemu
-$ ./configure --prefix=$HOME --with-tracewrap=../bap-frames --target-list=arm-linux-user
+$ ./configure --prefix=$HOME --with-tracewrap=<absolute-path-to>/bap-frames --target-list=arm-linux-user
 $ ninja -C build
 $ ninja -C build install
 ```


### PR DESCRIPTION
I get

```
../protobuf/raw/meson.build:7:0: ERROR: File ../bap-frames/piqi/frame.piqi does not exist.
```

if I use the relative path.