### PR TITLE
Hexagon trace support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,8 +34,8 @@ jobs:
       run: |
         git clone --depth 1 http://github.com/BinaryAnalysisPlatform/bap-frames.git
         git clone --depth 1 http://github.com/BinaryAnalysisPlatform/qemu.git
-    - name: Build without tracewrap
+    - name: Build for Hexagon
       run: |
         cd qemu
-        ./configure --prefix=$HOME --target-list=arm-linux-user
+        ./configure --prefix=$HOME --with-tracewrap="$HOME"/bap-frames --target-list=hexagon-linux-user
         ninja -C build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,5 +37,5 @@ jobs:
     - name: Build for Hexagon
       run: |
         cd qemu
-        ./configure --prefix=$HOME --with-tracewrap="$HOME"/bap-frames --target-list=hexagon-linux-user
+        opam exec -- ./configure --prefix=$HOME --with-tracewrap="$HOME"/bap-frames --target-list=hexagon-linux-user
         ninja -C build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,10 +30,17 @@ jobs:
     - name: Install piqi
       run: |
         opam install piqi
-    - name: Clone qemu and bap-frames
-      run: |
-        git clone --depth 1 http://github.com/BinaryAnalysisPlatform/bap-frames.git
-        git clone --depth 1 http://github.com/BinaryAnalysisPlatform/qemu.git
+    - name: Checkout bap-frames
+      uses: actions/checkout@v4
+      with:
+        repository: BinaryAnalysisPlatform/bap-frames
+        path: bap-frames
+    - name: Checkout qemu
+      uses: actions/checkout@v4
+      with:
+        repository: BinaryAnalysisPlatform/qemu
+        path: qemu
+        ref: tracewrap-8.1-hexagon
     - name: Build for Hexagon
       run: |
         cd qemu

--- a/linux-user/hexagon/trace_info.h
+++ b/linux-user/hexagon/trace_info.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "frame_arch.h"
+
+const uint64_t frame_arch = frame_arch_hexagon;
+const uint64_t frame_mach = frame_mach_hexagon_V6;

--- a/scripts/meson-buildoptions.sh
+++ b/scripts/meson-buildoptions.sh
@@ -50,6 +50,7 @@ meson_options_help() {
   printf "%s\n" '                           Set available tracing backends [log] (choices:'
   printf "%s\n" '                           dtrace/ftrace/log/nop/simple/syslog/ust)'
   printf "%s\n" '  --enable-tsan            enable thread sanitizer'
+  printf "%s\n" '  --enable-tracewrap       tracewrap (bap-frames) compression support'
   printf "%s\n" '  --firmwarepath=VALUES    search PATH for firmware files [share/qemu-'
   printf "%s\n" '                           firmware]'
   printf "%s\n" '  --iasl=VALUE             Path to ACPI disassembler'
@@ -66,6 +67,7 @@ meson_options_help() {
   printf "%s\n" '                           [NORMAL]'
   printf "%s\n" '  --with-coroutine=CHOICE  coroutine backend to use (choices:'
   printf "%s\n" '                           auto/sigaltstack/ucontext/windows)'
+  printf "%s\n" '  --tracewrap-dir=VALUE    path to bap-frames'
   printf "%s\n" '  --with-pkgversion=VALUE  use specified string as sub-version of the'
   printf "%s\n" '                           package'
   printf "%s\n" '  --with-trace-file=VALUE  Trace file prefix for simple backend [trace]'
@@ -468,6 +470,9 @@ _meson_option_parse() {
     --with-trace-file=*) quote_sh "-Dtrace_file=$2" ;;
     --enable-tsan) printf "%s" -Dtsan=true ;;
     --disable-tsan) printf "%s" -Dtsan=false ;;
+    --enable-tracewrap) printf "%s" -Dtracewrap=true ;;
+    --disable-tracewrap) printf "%s" -Dtracewrap=false ;;
+    --tracewrap-dir=*) quote_sh "-Dtracewrap_dir=$2" ;;
     --enable-u2f) printf "%s" -Du2f=enabled ;;
     --disable-u2f) printf "%s" -Du2f=disabled ;;
     --enable-usb-redir) printf "%s" -Dusb_redir=enabled ;;

--- a/target/hexagon/gen_tcg.h
+++ b/target/hexagon/gen_tcg.h
@@ -1368,5 +1368,6 @@
         tcg_gen_movi_tl(hex_gpr[HEX_REG_PC], ctx->pkt->pc); \
         TCGv excp = tcg_constant_tl(HEX_EXCP_TRAP0); \
         gen_helper_raise_exception(cpu_env, excp); \
+        gen_helper_trace_endframe(cpu_env, hex_gpr[HEX_REG_PC], tcg_constant_i32(1)); \
     } while (0)
 #endif

--- a/target/hexagon/gen_tcg.h
+++ b/target/hexagon/gen_tcg.h
@@ -1367,7 +1367,7 @@
         uiV = uiV; \
         tcg_gen_movi_tl(hex_gpr[HEX_REG_PC], ctx->pkt->pc); \
         TCGv excp = tcg_constant_tl(HEX_EXCP_TRAP0); \
-        gen_helper_raise_exception(cpu_env, excp); \
         gen_helper_trace_endframe(cpu_env, hex_gpr[HEX_REG_PC], tcg_constant_i32(1)); \
+        gen_helper_raise_exception(cpu_env, excp); \
     } while (0)
 #endif

--- a/target/hexagon/gen_tcg_funcs.py
+++ b/target/hexagon/gen_tcg_funcs.py
@@ -41,7 +41,7 @@ def genptr_decl_pair_writable(f, tag, regtype, regid, regno):
     f.write(f"    TCGv_i64 {regtype}{regid}V = " f"get_result_gpr_pair(ctx, {regN});\n")
     if regid in ["x", "y"]:
         f.write(
-            f"    gen_helper_trace_load_reg_pair(tcg_constant_i32({regN}), {regtype}{regid}V, tcg_constant_i32(true));\n"
+            f"    gen_helper_trace_load_reg_pair_new(tcg_constant_i32({regN}), {regtype}{regid}V);\n"
             )
 
 
@@ -52,21 +52,21 @@ def genptr_decl_writable(f, tag, regtype, regid, regno):
         f.write(f"    TCGv {regtype}{regid}V = get_result_gpr(ctx, {regN});\n")
         if regid in ["x", "y"]:
             f.write(
-                f"    gen_helper_trace_load_reg(tcg_constant_i32({regN}), {regtype}{regid}V, tcg_constant_i32(false));\n"
+                f"    gen_helper_trace_load_reg(tcg_constant_i32({regN}), {regtype}{regid}V);\n"
                 )
     elif regtype == "C":
         f.write(f"    const int {regN} = insn->regno[{regno}] + HEX_REG_SA0;\n")
         f.write(f"    TCGv {regtype}{regid}V = get_result_gpr(ctx, {regN});\n")
         if regid in ["x", "y"]:
             f.write(
-                f"    gen_helper_trace_load_reg(tcg_constant_i32({regN}), {regtype}{regid}V, tcg_constant_i32(false));\n"
+                f"    gen_helper_trace_load_reg(tcg_constant_i32({regN}), {regtype}{regid}V);\n"
                 )
     elif regtype == "P":
         f.write(f"    const int {regN} = insn->regno[{regno}];\n")
         f.write(f"    TCGv {regtype}{regid}V = tcg_temp_new();\n")
         if regid in ["x", "y"]:
             f.write(
-                f"    gen_helper_trace_load_pred(tcg_constant_i32({regN}), {regtype}{regid}V, tcg_constant_i32(false));\n"
+                f"    gen_helper_trace_load_pred(tcg_constant_i32({regN}), {regtype}{regid}V);\n"
                 )
     else:
         hex_common.bad_register(regtype, regid)
@@ -85,7 +85,7 @@ def genptr_decl(f, tag, regtype, regid, regno):
                 f"    TCGv {regtype}{regid}V = " f"hex_gpr[insn->regno[{regno}]];\n"
             )
             f.write(
-                f"    gen_helper_trace_load_reg(tcg_constant_i32(insn->regno[{regno}]), {regtype}{regid}V, tcg_constant_i32(false));\n"
+                f"    gen_helper_trace_load_reg(tcg_constant_i32(insn->regno[{regno}]), {regtype}{regid}V);\n"
             )
         elif regid in {"d", "e", "x", "y"}:
             genptr_decl_writable(f, tag, regtype, regid, regno)
@@ -97,7 +97,7 @@ def genptr_decl(f, tag, regtype, regid, regno):
                 f"    TCGv {regtype}{regid}V = " f"hex_pred[insn->regno[{regno}]];\n"
             )
             f.write(
-                f"    gen_helper_trace_load_pred(tcg_constant_i32(insn->regno[{regno}]), {regtype}{regid}V, tcg_constant_i32(false));\n"
+                f"    gen_helper_trace_load_pred(tcg_constant_i32(insn->regno[{regno}]), {regtype}{regid}V);\n"
                 )
         elif regid in {"d", "e", "x"}:
             genptr_decl_writable(f, tag, regtype, regid, regno)
@@ -127,7 +127,7 @@ def genptr_decl(f, tag, regtype, regid, regno):
                 "HEX_REG_M0];\n"
             )
             f.write(
-                f"    gen_helper_trace_load_reg(tcg_constant_i32({regtype}{regid}N + HEX_REG_M0), {regtype}{regid}V, tcg_constant_i32(false));\n"
+                f"    gen_helper_trace_load_reg(tcg_constant_i32({regtype}{regid}N + HEX_REG_M0), {regtype}{regid}V);\n"
                 )
         else:
             hex_common.bad_register(regtype, regid)
@@ -218,7 +218,7 @@ def genptr_decl_new(f, tag, regtype, regid, regno):
                 f"get_result_gpr(ctx, insn->regno[{regno}]);\n"
             )
             f.write(
-                f"    gen_helper_trace_load_reg(tcg_constant_i32(insn->regno[{regno}]), {regtype}{regid}N, tcg_constant_i32(true));\n"
+                f"    gen_helper_trace_load_reg_new(tcg_constant_i32(insn->regno[{regno}]), {regtype}{regid}N);\n"
                 )
         else:
             hex_common.bad_register(regtype, regid)
@@ -229,7 +229,7 @@ def genptr_decl_new(f, tag, regtype, regid, regno):
                 f"ctx->new_pred_value[insn->regno[{regno}]];\n"
             )
             f.write(
-                f"    gen_helper_trace_load_pred(tcg_constant_i32(insn->regno[{regno}]), {regtype}{regid}N, tcg_constant_i32(true));\n"
+                f"    gen_helper_trace_load_pred_new(tcg_constant_i32(insn->regno[{regno}]), {regtype}{regid}N);\n"
                 )
         else:
             hex_common.bad_register(regtype, regid)
@@ -288,7 +288,7 @@ def genptr_src_read(f, tag, regtype, regid):
                 f"{regid}N + 1]);\n"
             )
             f.write(
-                f"    gen_helper_trace_load_reg_pair(tcg_constant_i32({regtype}{regid}N), {regtype}{regid}V, tcg_constant_i32(false));\n"
+                f"    gen_helper_trace_load_reg_pair(tcg_constant_i32({regtype}{regid}N), {regtype}{regid}V);\n"
                 )
         elif regid in {"x", "y"}:
             ## For read/write registers, we need to get the original value into
@@ -300,7 +300,7 @@ def genptr_src_read(f, tag, regtype, regid):
                     f"hex_gpr[{regtype}{regid}N]);\n"
                 )
                 f.write(
-                    f"    gen_helper_trace_load_reg(tcg_constant_i32({regtype}{regid}N), {regtype}{regid}V, tcg_constant_i32(false));\n"
+                    f"    gen_helper_trace_load_reg(tcg_constant_i32({regtype}{regid}N), {regtype}{regid}V);\n"
                     )
         elif regid not in {"s", "t", "u", "v"}:
             hex_common.bad_register(regtype, regid)
@@ -311,7 +311,7 @@ def genptr_src_read(f, tag, regtype, regid):
                 f"hex_pred[{regtype}{regid}N]);\n"
             )
             f.write(
-                f"    gen_helper_trace_load_pred(tcg_constant_i32({regtype}{regid}N), {regtype}{regid}V, tcg_constant_i32(false));\n"
+                f"    gen_helper_trace_load_pred(tcg_constant_i32({regtype}{regid}N), {regtype}{regid}V);\n"
                 )
         elif regid not in {"s", "t", "u", "v"}:
             hex_common.bad_register(regtype, regid)

--- a/target/hexagon/gen_tcg_funcs.py
+++ b/target/hexagon/gen_tcg_funcs.py
@@ -68,6 +68,9 @@ def genptr_decl(f, tag, regtype, regid, regno):
             f.write(
                 f"    TCGv {regtype}{regid}V = " f"hex_gpr[insn->regno[{regno}]];\n"
             )
+            f.write(
+                f"       gen_trace_load_gpr(insn->regno[{regno}], hex_gpr[insn->regno[{regno}]]);\n"
+            )
         elif regid in {"d", "e", "x", "y"}:
             genptr_decl_writable(f, tag, regtype, regid, regno)
         else:
@@ -103,6 +106,9 @@ def genptr_decl(f, tag, regtype, regid, regno):
             f.write(
                 f"    TCGv {regtype}{regid}V = hex_gpr[{regtype}{regid}N + "
                 "HEX_REG_M0];\n"
+            )
+            f.write(
+                f"       gen_trace_load_gpr({regtype}{regid}N + HEX_REG_M0, hex_gpr[{regtype}{regid}N + HEX_REG_M0]);\n"
             )
         else:
             hex_common.bad_register(regtype, regid)

--- a/target/hexagon/gen_tcg_funcs.py
+++ b/target/hexagon/gen_tcg_funcs.py
@@ -68,9 +68,6 @@ def genptr_decl(f, tag, regtype, regid, regno):
             f.write(
                 f"    TCGv {regtype}{regid}V = " f"hex_gpr[insn->regno[{regno}]];\n"
             )
-            f.write(
-                f"       gen_trace_load_gpr(insn->regno[{regno}], hex_gpr[insn->regno[{regno}]]);\n"
-            )
         elif regid in {"d", "e", "x", "y"}:
             genptr_decl_writable(f, tag, regtype, regid, regno)
         else:
@@ -106,9 +103,6 @@ def genptr_decl(f, tag, regtype, regid, regno):
             f.write(
                 f"    TCGv {regtype}{regid}V = hex_gpr[{regtype}{regid}N + "
                 "HEX_REG_M0];\n"
-            )
-            f.write(
-                f"       gen_trace_load_gpr({regtype}{regid}N + HEX_REG_M0, hex_gpr[{regtype}{regid}N + HEX_REG_M0]);\n"
             )
         else:
             hex_common.bad_register(regtype, regid)

--- a/target/hexagon/gen_tcg_funcs.py
+++ b/target/hexagon/gen_tcg_funcs.py
@@ -39,6 +39,13 @@ def genptr_decl_pair_writable(f, tag, regtype, regid, regno):
     else:
         hex_common.bad_register(regtype, regid)
     f.write(f"    TCGv_i64 {regtype}{regid}V = " f"get_result_gpr_pair(ctx, {regN});\n")
+    f.write(
+        f"    gen_helper_trace_load_reg_pair(tcg_constant_i32(insn->regno["
+    )
+    if regtype == "C":
+        f.write(f"{regno}] + HEX_REG_SA0), {regtype}{regid}V, tcg_constant_i32(false));\n")
+    else:
+        f.write(f"{regno}]), {regtype}{regid}V, tcg_constant_i32(false));\n")
 
 
 def genptr_decl_writable(f, tag, regtype, regid, regno):
@@ -54,6 +61,13 @@ def genptr_decl_writable(f, tag, regtype, regid, regno):
         f.write(f"    TCGv {regtype}{regid}V = tcg_temp_new();\n")
     else:
         hex_common.bad_register(regtype, regid)
+    f.write(
+        f"    gen_helper_trace_load_reg(tcg_constant_i32(insn->regno["
+    )
+    if regtype == "C":
+        f.write(f"{regno}] + HEX_REG_SA0), {regtype}{regid}V, tcg_constant_i32(false));\n")
+    else:
+        f.write(f"{regno}]), {regtype}{regid}V, tcg_constant_i32(false));\n")
 
 
 def genptr_decl(f, tag, regtype, regid, regno):
@@ -67,6 +81,9 @@ def genptr_decl(f, tag, regtype, regid, regno):
         elif regid in {"s", "t", "u", "v"}:
             f.write(
                 f"    TCGv {regtype}{regid}V = " f"hex_gpr[insn->regno[{regno}]];\n"
+            )
+            f.write(
+                f"    gen_helper_trace_load_reg(tcg_constant_i32(insn->regno[{regno}]), {regtype}{regid}V, tcg_constant_i32(false));\n"
             )
         elif regid in {"d", "e", "x", "y"}:
             genptr_decl_writable(f, tag, regtype, regid, regno)

--- a/target/hexagon/gen_tcg_funcs.py
+++ b/target/hexagon/gen_tcg_funcs.py
@@ -39,11 +39,6 @@ def genptr_decl_pair_writable(f, tag, regtype, regid, regno):
     else:
         hex_common.bad_register(regtype, regid)
     f.write(f"    TCGv_i64 {regtype}{regid}V = " f"get_result_gpr_pair(ctx, {regN});\n")
-    if regid in ["x", "y"]:
-        f.write(
-            f"    gen_helper_trace_load_reg_pair_new(tcg_constant_i32({regN}), {regtype}{regid}V);\n"
-            )
-
 
 def genptr_decl_writable(f, tag, regtype, regid, regno):
     regN = f"{regtype}{regid}N"
@@ -287,9 +282,6 @@ def genptr_src_read(f, tag, regtype, regid):
                 f"                                 hex_gpr[{regtype}"
                 f"{regid}N + 1]);\n"
             )
-            f.write(
-                f"    gen_helper_trace_load_reg_pair(tcg_constant_i32({regtype}{regid}N), {regtype}{regid}V);\n"
-                )
         elif regid in {"x", "y"}:
             ## For read/write registers, we need to get the original value into
             ## the result TCGv.  For conditional instructions, this is done in

--- a/target/hexagon/gen_tcg_funcs.py
+++ b/target/hexagon/gen_tcg_funcs.py
@@ -39,9 +39,10 @@ def genptr_decl_pair_writable(f, tag, regtype, regid, regno):
     else:
         hex_common.bad_register(regtype, regid)
     f.write(f"    TCGv_i64 {regtype}{regid}V = " f"get_result_gpr_pair(ctx, {regN});\n")
-    f.write(
-        f"    gen_helper_trace_load_reg_pair(tcg_constant_i32({regN}), {regtype}{regid}V, tcg_constant_i32(true));\n"
-        )
+    if regid in ["x", "y"]:
+        f.write(
+            f"    gen_helper_trace_load_reg_pair(tcg_constant_i32({regN}), {regtype}{regid}V, tcg_constant_i32(true));\n"
+            )
 
 
 def genptr_decl_writable(f, tag, regtype, regid, regno):
@@ -49,21 +50,24 @@ def genptr_decl_writable(f, tag, regtype, regid, regno):
     if regtype == "R":
         f.write(f"    const int {regN} = insn->regno[{regno}];\n")
         f.write(f"    TCGv {regtype}{regid}V = get_result_gpr(ctx, {regN});\n")
-        f.write(
-            f"    gen_helper_trace_load_reg(tcg_constant_i32({regN}), {regtype}{regid}V, tcg_constant_i32(false));\n"
-            )
+        if regid in ["x", "y"]:
+            f.write(
+                f"    gen_helper_trace_load_reg(tcg_constant_i32({regN}), {regtype}{regid}V, tcg_constant_i32(false));\n"
+                )
     elif regtype == "C":
         f.write(f"    const int {regN} = insn->regno[{regno}] + HEX_REG_SA0;\n")
         f.write(f"    TCGv {regtype}{regid}V = get_result_gpr(ctx, {regN});\n")
-        f.write(
-            f"    gen_helper_trace_load_reg(tcg_constant_i32({regN}), {regtype}{regid}V, tcg_constant_i32(false));\n"
-            )
+        if regid in ["x", "y"]:
+            f.write(
+                f"    gen_helper_trace_load_reg(tcg_constant_i32({regN}), {regtype}{regid}V, tcg_constant_i32(false));\n"
+                )
     elif regtype == "P":
         f.write(f"    const int {regN} = insn->regno[{regno}];\n")
         f.write(f"    TCGv {regtype}{regid}V = tcg_temp_new();\n")
-        f.write(
-            f"    gen_helper_trace_load_pred(tcg_constant_i32({regN}), {regtype}{regid}V, tcg_constant_i32(false));\n"
-            )
+        if regid in ["x", "y"]:
+            f.write(
+                f"    gen_helper_trace_load_pred(tcg_constant_i32({regN}), {regtype}{regid}V, tcg_constant_i32(false));\n"
+                )
     else:
         hex_common.bad_register(regtype, regid)
 

--- a/target/hexagon/gen_tcg_funcs.py
+++ b/target/hexagon/gen_tcg_funcs.py
@@ -39,6 +39,9 @@ def genptr_decl_pair_writable(f, tag, regtype, regid, regno):
     else:
         hex_common.bad_register(regtype, regid)
     f.write(f"    TCGv_i64 {regtype}{regid}V = " f"get_result_gpr_pair(ctx, {regN});\n")
+    f.write(
+        f"    gen_helper_trace_load_reg_pair(tcg_constant_i32({regN}), {regtype}{regid}V, tcg_constant_i32(true));\n"
+        )
 
 
 def genptr_decl_writable(f, tag, regtype, regid, regno):
@@ -46,12 +49,21 @@ def genptr_decl_writable(f, tag, regtype, regid, regno):
     if regtype == "R":
         f.write(f"    const int {regN} = insn->regno[{regno}];\n")
         f.write(f"    TCGv {regtype}{regid}V = get_result_gpr(ctx, {regN});\n")
+        f.write(
+            f"    gen_helper_trace_load_reg(tcg_constant_i32({regN}), {regtype}{regid}V, tcg_constant_i32(false));\n"
+            )
     elif regtype == "C":
         f.write(f"    const int {regN} = insn->regno[{regno}] + HEX_REG_SA0;\n")
         f.write(f"    TCGv {regtype}{regid}V = get_result_gpr(ctx, {regN});\n")
+        f.write(
+            f"    gen_helper_trace_load_reg(tcg_constant_i32({regN}), {regtype}{regid}V, tcg_constant_i32(false));\n"
+            )
     elif regtype == "P":
         f.write(f"    const int {regN} = insn->regno[{regno}];\n")
         f.write(f"    TCGv {regtype}{regid}V = tcg_temp_new();\n")
+        f.write(
+            f"    gen_helper_trace_load_pred(tcg_constant_i32({regN}), {regtype}{regid}V, tcg_constant_i32(false));\n"
+            )
     else:
         hex_common.bad_register(regtype, regid)
 
@@ -201,6 +213,9 @@ def genptr_decl_new(f, tag, regtype, regid, regno):
                 f"    TCGv {regtype}{regid}N = "
                 f"get_result_gpr(ctx, insn->regno[{regno}]);\n"
             )
+            f.write(
+                f"    gen_helper_trace_load_reg(tcg_constant_i32(insn->regno[{regno}]), {regtype}{regid}N, tcg_constant_i32(true));\n"
+                )
         else:
             hex_common.bad_register(regtype, regid)
     elif regtype == "P":

--- a/target/hexagon/gen_tcg_funcs.py
+++ b/target/hexagon/gen_tcg_funcs.py
@@ -45,24 +45,12 @@ def genptr_decl_writable(f, tag, regtype, regid, regno):
     if regtype == "R":
         f.write(f"    const int {regN} = insn->regno[{regno}];\n")
         f.write(f"    TCGv {regtype}{regid}V = get_result_gpr(ctx, {regN});\n")
-        if regid in ["x", "y"]:
-            f.write(
-                f"    gen_helper_trace_load_reg(tcg_constant_i32({regN}), {regtype}{regid}V);\n"
-                )
     elif regtype == "C":
         f.write(f"    const int {regN} = insn->regno[{regno}] + HEX_REG_SA0;\n")
         f.write(f"    TCGv {regtype}{regid}V = get_result_gpr(ctx, {regN});\n")
-        if regid in ["x", "y"]:
-            f.write(
-                f"    gen_helper_trace_load_reg(tcg_constant_i32({regN}), {regtype}{regid}V);\n"
-                )
     elif regtype == "P":
         f.write(f"    const int {regN} = insn->regno[{regno}];\n")
         f.write(f"    TCGv {regtype}{regid}V = tcg_temp_new();\n")
-        if regid in ["x", "y"]:
-            f.write(
-                f"    gen_helper_trace_load_pred(tcg_constant_i32({regN}), {regtype}{regid}V);\n"
-                )
     else:
         hex_common.bad_register(regtype, regid)
 
@@ -79,9 +67,6 @@ def genptr_decl(f, tag, regtype, regid, regno):
             f.write(
                 f"    TCGv {regtype}{regid}V = " f"hex_gpr[insn->regno[{regno}]];\n"
             )
-            f.write(
-                f"    gen_helper_trace_load_reg(tcg_constant_i32(insn->regno[{regno}]), {regtype}{regid}V);\n"
-            )
         elif regid in {"d", "e", "x", "y"}:
             genptr_decl_writable(f, tag, regtype, regid, regno)
         else:
@@ -91,9 +76,6 @@ def genptr_decl(f, tag, regtype, regid, regno):
             f.write(
                 f"    TCGv {regtype}{regid}V = " f"hex_pred[insn->regno[{regno}]];\n"
             )
-            f.write(
-                f"    gen_helper_trace_load_pred(tcg_constant_i32(insn->regno[{regno}]), {regtype}{regid}V);\n"
-                )
         elif regid in {"d", "e", "x"}:
             genptr_decl_writable(f, tag, regtype, regid, regno)
         else:
@@ -121,9 +103,6 @@ def genptr_decl(f, tag, regtype, regid, regno):
                 f"    TCGv {regtype}{regid}V = hex_gpr[{regtype}{regid}N + "
                 "HEX_REG_M0];\n"
             )
-            f.write(
-                f"    gen_helper_trace_load_reg(tcg_constant_i32({regtype}{regid}N + HEX_REG_M0), {regtype}{regid}V);\n"
-                )
         else:
             hex_common.bad_register(regtype, regid)
     elif regtype == "V":
@@ -212,9 +191,6 @@ def genptr_decl_new(f, tag, regtype, regid, regno):
                 f"    TCGv {regtype}{regid}N = "
                 f"get_result_gpr(ctx, insn->regno[{regno}]);\n"
             )
-            f.write(
-                f"    gen_helper_trace_load_reg_new(tcg_constant_i32(insn->regno[{regno}]), {regtype}{regid}N);\n"
-                )
         else:
             hex_common.bad_register(regtype, regid)
     elif regtype == "P":
@@ -223,9 +199,6 @@ def genptr_decl_new(f, tag, regtype, regid, regno):
                 f"    TCGv {regtype}{regid}N = "
                 f"ctx->new_pred_value[insn->regno[{regno}]];\n"
             )
-            f.write(
-                f"    gen_helper_trace_load_pred_new(tcg_constant_i32(insn->regno[{regno}]), {regtype}{regid}N);\n"
-                )
         else:
             hex_common.bad_register(regtype, regid)
     elif regtype == "O":
@@ -291,9 +264,6 @@ def genptr_src_read(f, tag, regtype, regid):
                     f"    tcg_gen_mov_tl({regtype}{regid}V, "
                     f"hex_gpr[{regtype}{regid}N]);\n"
                 )
-                f.write(
-                    f"    gen_helper_trace_load_reg(tcg_constant_i32({regtype}{regid}N), {regtype}{regid}V);\n"
-                    )
         elif regid not in {"s", "t", "u", "v"}:
             hex_common.bad_register(regtype, regid)
     elif regtype == "P":
@@ -302,9 +272,6 @@ def genptr_src_read(f, tag, regtype, regid):
                 f"    tcg_gen_mov_tl({regtype}{regid}V, "
                 f"hex_pred[{regtype}{regid}N]);\n"
             )
-            f.write(
-                f"    gen_helper_trace_load_pred(tcg_constant_i32({regtype}{regid}N), {regtype}{regid}V);\n"
-                )
         elif regid not in {"s", "t", "u", "v"}:
             hex_common.bad_register(regtype, regid)
     elif regtype == "C":

--- a/target/hexagon/genptr.c
+++ b/target/hexagon/genptr.c
@@ -425,6 +425,7 @@ void gen_store32(TCGv vaddr, TCGv src, int width, uint32_t slot)
     tcg_gen_mov_tl(hex_store_addr[slot], vaddr);
     tcg_gen_movi_tl(hex_store_width[slot], width);
     tcg_gen_mov_tl(hex_store_val32[slot], src);
+    gen_helper_trace_store_mem(vaddr, src, tcg_constant_i32(width));
 }
 
 void gen_store1(TCGv_env cpu_env, TCGv vaddr, TCGv src, uint32_t slot)
@@ -465,6 +466,7 @@ void gen_store8(TCGv_env cpu_env, TCGv vaddr, TCGv_i64 src, uint32_t slot)
     tcg_gen_mov_tl(hex_store_addr[slot], vaddr);
     tcg_gen_movi_tl(hex_store_width[slot], 8);
     tcg_gen_mov_i64(hex_store_val64[slot], src);
+    gen_helper_trace_store_mem_64(vaddr, src, tcg_constant_i32(8));
 }
 
 void gen_store8i(TCGv_env cpu_env, TCGv vaddr, int64_t src, uint32_t slot)

--- a/target/hexagon/genptr.c
+++ b/target/hexagon/genptr.c
@@ -100,14 +100,16 @@ void gen_log_reg_write(DisasContext *ctx, int rnum, TCGv val)
 
     gen_masked_reg_write(val, hex_gpr[rnum], reg_mask);
     tcg_gen_mov_tl(get_result_gpr(ctx, rnum), val);
-    if (ctx->need_commit) {
-        gen_helper_trace_store_reg_new(tcg_constant_i32(rnum), val);
-    } else {
-        gen_helper_trace_store_reg(tcg_constant_i32(rnum), val);
-    }
     if (HEX_DEBUG) {
         /* Do this so HELPER(debug_commit_end) will know */
         tcg_gen_movi_tl(hex_reg_written[rnum], 1);
+    }
+    if (rnum != HEX_REG_PC) {
+        if (ctx->need_commit) {
+            gen_helper_trace_store_reg_new(tcg_constant_i32(rnum), val);
+        } else {
+            gen_helper_trace_store_reg(tcg_constant_i32(rnum), val);
+        }
     }
 }
 

--- a/target/hexagon/genptr.c
+++ b/target/hexagon/genptr.c
@@ -535,6 +535,7 @@ void gen_set_usr_field(DisasContext *ctx, int field, TCGv val)
     tcg_gen_deposit_tl(usr, usr, val,
                        reg_field_info[field].offset,
                        reg_field_info[field].width);
+    gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_USR), usr);
 }
 
 void gen_set_usr_fieldi(DisasContext *ctx, int field, int x)
@@ -547,6 +548,7 @@ void gen_set_usr_fieldi(DisasContext *ctx, int field, int x)
         } else {
             tcg_gen_andi_tl(usr, usr, ~bit);
         }
+        gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_USR), usr);
     } else {
         TCGv val = tcg_constant_tl(x);
         gen_set_usr_field(ctx, field, val);
@@ -925,6 +927,11 @@ static void gen_endloop0(DisasContext *ctx)
             TCGv lc0 = get_result_gpr(ctx, HEX_REG_LC0);
             gen_jumpr(ctx, hex_gpr[HEX_REG_SA0]);
             tcg_gen_subi_tl(lc0, hex_gpr[HEX_REG_LC0], 1);
+            if (ctx->need_commit) {
+                gen_helper_trace_store_reg_new(tcg_constant_i32(HEX_REG_LC0), lc0);
+            } else {
+                gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_LC0), lc0);
+            }
         }
         gen_set_label(label3);
     }
@@ -944,6 +951,11 @@ static void gen_endloop1(DisasContext *ctx)
         TCGv lc1 = get_result_gpr(ctx, HEX_REG_LC1);
         gen_jumpr(ctx, hex_gpr[HEX_REG_SA1]);
         tcg_gen_subi_tl(lc1, hex_gpr[HEX_REG_LC1], 1);
+        if (ctx->need_commit) {
+            gen_helper_trace_store_reg_new(tcg_constant_i32(HEX_REG_LC1), lc1);
+        } else {
+            gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_LC1), lc1);
+        }
     }
     gen_set_label(label);
 }
@@ -995,6 +1007,11 @@ static void gen_endloop01(DisasContext *ctx)
         TCGv lc0 = get_result_gpr(ctx, HEX_REG_LC0);
         gen_jumpr(ctx, hex_gpr[HEX_REG_SA0]);
         tcg_gen_subi_tl(lc0, hex_gpr[HEX_REG_LC0], 1);
+        if (ctx->need_commit) {
+            gen_helper_trace_store_reg_new(tcg_constant_i32(HEX_REG_LC0), lc0);
+        } else {
+            gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_LC0), lc0);
+        }
         tcg_gen_br(done);
     }
     gen_set_label(label3);
@@ -1003,6 +1020,11 @@ static void gen_endloop01(DisasContext *ctx)
         TCGv lc1 = get_result_gpr(ctx, HEX_REG_LC1);
         gen_jumpr(ctx, hex_gpr[HEX_REG_SA1]);
         tcg_gen_subi_tl(lc1, hex_gpr[HEX_REG_LC1], 1);
+        if (ctx->need_commit) {
+            gen_helper_trace_store_reg_new(tcg_constant_i32(HEX_REG_LC1), lc1);
+        } else {
+            gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_LC1), lc1);
+        }
     }
     gen_set_label(done);
 }

--- a/target/hexagon/genptr.c
+++ b/target/hexagon/genptr.c
@@ -723,7 +723,11 @@ static void gen_call(DisasContext *ctx, int pc_off)
 {
     TCGv lr = get_result_gpr(ctx, HEX_REG_LR);
     tcg_gen_movi_tl(lr, ctx->next_PC);
-    gen_helper_trace_store_reg_new(tcg_constant_i32(HEX_REG_LR), lr);
+    if (ctx->need_commit) {
+        gen_helper_trace_store_reg_new(tcg_constant_i32(HEX_REG_LR), lr);
+    } else {
+        gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_LR), lr);
+    }
     gen_write_new_pc_pcrel(ctx, pc_off, TCG_COND_ALWAYS, NULL);
 }
 
@@ -731,7 +735,11 @@ static void gen_callr(DisasContext *ctx, TCGv new_pc)
 {
     TCGv lr = get_result_gpr(ctx, HEX_REG_LR);
     tcg_gen_movi_tl(lr, ctx->next_PC);
-    gen_helper_trace_store_reg_new(tcg_constant_i32(HEX_REG_LR), lr);
+    if (ctx->need_commit) {
+        gen_helper_trace_store_reg_new(tcg_constant_i32(HEX_REG_LR), lr);
+    } else {
+        gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_LR), lr);
+    }
     gen_write_new_pc_addr(ctx, new_pc, TCG_COND_ALWAYS, NULL);
 }
 
@@ -745,7 +753,11 @@ static void gen_cond_call(DisasContext *ctx, TCGv pred,
     gen_write_new_pc_pcrel(ctx, pc_off, cond, lsb);
     tcg_gen_brcondi_tl(cond, lsb, 0, skip);
     tcg_gen_movi_tl(lr, ctx->next_PC);
-    gen_helper_trace_store_reg_new(tcg_constant_i32(HEX_REG_LR), lr);
+    if (ctx->need_commit) {
+        gen_helper_trace_store_reg_new(tcg_constant_i32(HEX_REG_LR), lr);
+    } else {
+        gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_LR), lr);
+    }
     gen_set_label(skip);
 }
 

--- a/target/hexagon/genptr.c
+++ b/target/hexagon/genptr.c
@@ -129,8 +129,10 @@ TCGv get_result_pred(DisasContext *ctx, int pnum)
             ctx->new_pred_value[pnum] = tcg_temp_new();
             tcg_gen_movi_tl(ctx->new_pred_value[pnum], 0);
         }
+        gen_helper_trace_load_pred_new(tcg_constant_i32(pnum), ctx->new_pred_value[pnum]);
         return ctx->new_pred_value[pnum];
     } else {
+        gen_helper_trace_load_pred(tcg_constant_i32(pnum), hex_pred[pnum]);
         return hex_pred[pnum];
     }
 }

--- a/target/hexagon/genptr.c
+++ b/target/hexagon/genptr.c
@@ -211,7 +211,7 @@ static inline void gen_read_ctrl_reg(DisasContext *ctx, const int reg_num,
     } else {
         tcg_gen_mov_tl(dest, hex_gpr[reg_num]);
     }
-    if (reg_num != HEX_REG_P3_0_ALIASED) {
+    if (reg_num != HEX_REG_P3_0_ALIASED && reg_num != HEX_REG_PC) {
         gen_helper_trace_load_reg(tcg_constant_i32(reg_num), dest);
     }
 }
@@ -521,7 +521,6 @@ static void gen_write_new_pc_addr(DisasContext *ctx, TCGv addr,
     } else {
         tcg_gen_mov_tl(hex_gpr[HEX_REG_PC], addr);
     }
-    gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_PC), hex_gpr[HEX_REG_PC]);
 
     if (cond != TCG_COND_ALWAYS) {
         gen_set_label(pred_false);

--- a/target/hexagon/genptr.c
+++ b/target/hexagon/genptr.c
@@ -429,7 +429,7 @@ void gen_store32(TCGv vaddr, TCGv src, int width, uint32_t slot)
     tcg_gen_mov_tl(hex_store_addr[slot], vaddr);
     tcg_gen_movi_tl(hex_store_width[slot], width);
     tcg_gen_mov_tl(hex_store_val32[slot], src);
-    gen_helper_trace_store_mem(vaddr, src, tcg_constant_i32(width));
+    gen_helper_trace_store_mem(vaddr, src, tcg_constant_i32(size_memop(width)));
 }
 
 void gen_store1(TCGv_env cpu_env, TCGv vaddr, TCGv src, uint32_t slot)
@@ -470,7 +470,7 @@ void gen_store8(TCGv_env cpu_env, TCGv vaddr, TCGv_i64 src, uint32_t slot)
     tcg_gen_mov_tl(hex_store_addr[slot], vaddr);
     tcg_gen_movi_tl(hex_store_width[slot], 8);
     tcg_gen_mov_i64(hex_store_val64[slot], src);
-    gen_helper_trace_store_mem_64(vaddr, src, tcg_constant_i32(8));
+    gen_helper_trace_store_mem_64(vaddr, src, tcg_constant_i32(size_memop(8)));
 }
 
 void gen_store8i(TCGv_env cpu_env, TCGv vaddr, int64_t src, uint32_t slot)

--- a/target/hexagon/genptr.c
+++ b/target/hexagon/genptr.c
@@ -79,11 +79,9 @@ TCGv get_result_gpr(DisasContext *ctx, int rnum)
                 ctx->new_value[rnum] = tcg_temp_new();
                 tcg_gen_movi_tl(ctx->new_value[rnum], 0);
             }
-            gen_helper_trace_load_reg(tcg_constant_i32(rnum), ctx->new_value[rnum], tcg_constant_i32(true));
             return ctx->new_value[rnum];
         }
     } else {
-        gen_helper_trace_load_reg(tcg_constant_i32(rnum), hex_gpr[rnum], tcg_constant_i32(false));
         return hex_gpr[rnum];
     }
 }

--- a/target/hexagon/genptr.c
+++ b/target/hexagon/genptr.c
@@ -914,7 +914,7 @@ static void gen_endloop0(DisasContext *ctx)
 
     TCGLabel *label_lc0_decr = gen_new_label();
     tcg_gen_brcondi_tl(TCG_COND_LEU, hex_gpr[HEX_REG_LC0], 1, label_lc0_decr);
-    TCGv lc0_tmp = get_result_gpr(ctx, HEX_REG_LC0);
+    TCGv lc0_tmp = tcg_temp_new();
     tcg_gen_subi_tl(lc0_tmp, hex_gpr[HEX_REG_LC0], 1);
     gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_LC0), lc0_tmp);
     gen_set_label(label_lc0_decr);

--- a/target/hexagon/genptr.c
+++ b/target/hexagon/genptr.c
@@ -285,9 +285,9 @@ static inline void gen_write_ctrl_reg_pair(DisasContext *ctx, int reg_num,
         tcg_gen_mov_tl(result, val32);
         // p3_0 already written in gen_write_p3_0
         if (ctx->need_commit) {
-            gen_helper_trace_store_reg_new(tcg_constant_i32(reg_num), val32);
+            gen_helper_trace_store_reg_new(tcg_constant_i32(reg_num + 1), val32);
         } else {
-            gen_helper_trace_store_reg(tcg_constant_i32(reg_num), val32);
+            gen_helper_trace_store_reg(tcg_constant_i32(reg_num + 1), val32);
         }
     } else {
         gen_log_reg_write_pair(ctx, reg_num, val);

--- a/target/hexagon/genptr.c
+++ b/target/hexagon/genptr.c
@@ -24,6 +24,7 @@
 #include "insn.h"
 #include "opcodes.h"
 #include "translate.h"
+#include "helper.h"
 #define QEMU_GENERATE       /* Used internally by macros.h */
 #include "macros.h"
 #include "mmvec/macros.h"
@@ -91,6 +92,8 @@ static TCGv_i64 get_result_gpr_pair(DisasContext *ctx, int rnum)
     TCGv_i64 result = tcg_temp_new_i64();
     tcg_gen_concat_i32_i64(result, get_result_gpr(ctx, rnum),
                                    get_result_gpr(ctx, rnum + 1));
+    gen_trace_store_gpr({regN}, hex_gpr[rnum]);
+    gen_trace_store_gpr({regN}, hex_gpr[rnum + 1]);
     return result;
 }
 

--- a/target/hexagon/genptr.c
+++ b/target/hexagon/genptr.c
@@ -24,7 +24,6 @@
 #include "insn.h"
 #include "opcodes.h"
 #include "translate.h"
-#include "helper.h"
 #define QEMU_GENERATE       /* Used internally by macros.h */
 #include "macros.h"
 #include "mmvec/macros.h"
@@ -92,8 +91,6 @@ static TCGv_i64 get_result_gpr_pair(DisasContext *ctx, int rnum)
     TCGv_i64 result = tcg_temp_new_i64();
     tcg_gen_concat_i32_i64(result, get_result_gpr(ctx, rnum),
                                    get_result_gpr(ctx, rnum + 1));
-    gen_trace_store_gpr({regN}, hex_gpr[rnum]);
-    gen_trace_store_gpr({regN}, hex_gpr[rnum + 1]);
     return result;
 }
 

--- a/target/hexagon/genptr.c
+++ b/target/hexagon/genptr.c
@@ -105,7 +105,7 @@ void gen_log_reg_write(DisasContext *ctx, int rnum, TCGv val)
         tcg_gen_movi_tl(hex_reg_written[rnum], 1);
     }
     if (rnum != HEX_REG_PC) {
-        if (ctx->need_commit) {
+        if (ctx->need_commit && rnum != HEX_REG_LC0) {
             gen_helper_trace_store_reg_new(tcg_constant_i32(rnum), val);
         } else {
             gen_helper_trace_store_reg(tcg_constant_i32(rnum), val);
@@ -955,11 +955,7 @@ static void gen_endloop1(DisasContext *ctx)
         TCGv lc1 = get_result_gpr(ctx, HEX_REG_LC1);
         gen_jumpr(ctx, hex_gpr[HEX_REG_SA1]);
         tcg_gen_subi_tl(lc1, hex_gpr[HEX_REG_LC1], 1);
-        if (ctx->need_commit) {
-            gen_helper_trace_store_reg_new(tcg_constant_i32(HEX_REG_LC1), lc1);
-        } else {
-            gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_LC1), lc1);
-        }
+        gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_LC1), lc1);
     }
     gen_set_label(label);
 }
@@ -1011,11 +1007,7 @@ static void gen_endloop01(DisasContext *ctx)
         TCGv lc0 = get_result_gpr(ctx, HEX_REG_LC0);
         gen_jumpr(ctx, hex_gpr[HEX_REG_SA0]);
         tcg_gen_subi_tl(lc0, hex_gpr[HEX_REG_LC0], 1);
-        if (ctx->need_commit) {
-            gen_helper_trace_store_reg_new(tcg_constant_i32(HEX_REG_LC0), lc0);
-        } else {
-            gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_LC0), lc0);
-        }
+        gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_LC0), lc0);
         tcg_gen_br(done);
     }
     gen_set_label(label3);
@@ -1024,11 +1016,7 @@ static void gen_endloop01(DisasContext *ctx)
         TCGv lc1 = get_result_gpr(ctx, HEX_REG_LC1);
         gen_jumpr(ctx, hex_gpr[HEX_REG_SA1]);
         tcg_gen_subi_tl(lc1, hex_gpr[HEX_REG_LC1], 1);
-        if (ctx->need_commit) {
-            gen_helper_trace_store_reg_new(tcg_constant_i32(HEX_REG_LC1), lc1);
-        } else {
-            gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_LC1), lc1);
-        }
+        gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_LC1), lc1);
     }
     gen_set_label(done);
 }

--- a/target/hexagon/genptr.c
+++ b/target/hexagon/genptr.c
@@ -166,8 +166,12 @@ void gen_log_pred_write(DisasContext *ctx, int pnum, TCGv val)
     if (HEX_DEBUG) {
         tcg_gen_ori_tl(ctx->pred_written, ctx->pred_written, 1 << pnum);
     }
-    gen_helper_trace_store_pred_new(tcg_constant_i32(pnum), pred);
     set_bit(pnum, ctx->pregs_written);
+    if (ctx->need_commit) {
+        gen_helper_trace_store_pred_new(tcg_constant_i32(pnum), pred);
+    } else {
+        gen_helper_trace_store_pred(tcg_constant_i32(pnum), pred);
+    }
 }
 
 static inline void gen_read_p3_0(TCGv control_reg)

--- a/target/hexagon/helper.h
+++ b/target/hexagon/helper.h
@@ -114,8 +114,8 @@ DEF_HELPER_2(probe_pkt_scalar_hvx_stores, void, env, int)
 #ifdef HAS_TRACEWRAP
 // Frames
 // name, return type, (CPU env), address
-DEF_HELPER_1(trace_newframe, void, i64)
-DEF_HELPER_2(trace_endframe, void, env, i64)
+DEF_HELPER_1(trace_newframe, void, target_ulong)
+DEF_HELPER_2(trace_endframe, void, env, target_ulong, i32)
 
 // Memory
 // name, return type, address, val, width

--- a/target/hexagon/helper.h
+++ b/target/hexagon/helper.h
@@ -130,10 +130,6 @@ DEF_HELPER_2(trace_load_reg, void, i32, i32)
 DEF_HELPER_2(trace_load_reg_new, void, i32, i32)
 DEF_HELPER_2(trace_store_reg, void, i32, i32)
 
-DEF_HELPER_2(trace_load_reg_pair, void, i32, i64)
-DEF_HELPER_2(trace_load_reg_pair_new, void, i32, i64)
-DEF_HELPER_2(trace_store_reg_pair, void, i32, i64)
-
 // VRegs
 // name, return type, vreg, val, load_new
 DEF_HELPER_2(trace_load_vreg, void, i32, ptr)

--- a/target/hexagon/helper.h
+++ b/target/hexagon/helper.h
@@ -124,8 +124,10 @@ DEF_HELPER_3(trace_store_mem, void, tl, i64, i32)
 
 // GPRs
 // name, return type, reg, val, is_tmp
-DEF_HELPER_3(trace_load_reg, void, i32, tl, i32)
-DEF_HELPER_3(trace_store_reg, void, i32, tl, i32)
+DEF_HELPER_3(trace_load_reg, void, i32, i32, i32)
+DEF_HELPER_3(trace_store_reg, void, i32, i32, i32)
+DEF_HELPER_3(trace_load_reg_pair, void, i32, i64, i32)
+DEF_HELPER_3(trace_store_reg_pair, void, i32, i64, i32)
 
 // VRegs
 // name, return type, vreg, val, is_tmp

--- a/target/hexagon/helper.h
+++ b/target/hexagon/helper.h
@@ -119,8 +119,10 @@ DEF_HELPER_3(trace_endframe, void, env, tl, i32)
 
 // Memory
 // name, return type, address, val, width
-DEF_HELPER_3(trace_load_mem, void, tl, i64, i32)
-DEF_HELPER_3(trace_store_mem, void, tl, i64, i32)
+DEF_HELPER_3(trace_load_mem, void, tl, tl, i32)
+DEF_HELPER_3(trace_store_mem, void, tl, tl, i32)
+DEF_HELPER_3(trace_load_mem_64, void, tl, i64, i32)
+DEF_HELPER_3(trace_store_mem_64, void, tl, i64, i32)
 
 // GPRs
 // name, return type, reg, val, (load_new)

--- a/target/hexagon/helper.h
+++ b/target/hexagon/helper.h
@@ -123,27 +123,23 @@ DEF_HELPER_3(trace_load_mem, void, tl, i64, i32)
 DEF_HELPER_3(trace_store_mem, void, tl, i64, i32)
 
 // GPRs
-// name, return type, reg, val, is_tmp
+// name, return type, reg, val, (load_new)
 DEF_HELPER_3(trace_load_reg, void, i32, i32, i32)
-DEF_HELPER_3(trace_store_reg, void, i32, i32, i32)
+DEF_HELPER_2(trace_store_reg, void, i32, i32)
 DEF_HELPER_3(trace_load_reg_pair, void, i32, i64, i32)
-DEF_HELPER_3(trace_store_reg_pair, void, i32, i64, i32)
+DEF_HELPER_2(trace_store_reg_pair, void, i32, i64)
 
 // VRegs
-// name, return type, vreg, val, is_tmp
+// name, return type, vreg, val, load_new
 DEF_HELPER_3(trace_load_vreg, void, i32, ptr, i32)
-DEF_HELPER_3(trace_store_vreg, void, i32, ptr, i32)
+DEF_HELPER_2(trace_store_vreg, void, i32, ptr)
 
 // Predicates
-// name, return type, pred reg, val, is_tmp
+// name, return type, pred reg, val, load_new
 DEF_HELPER_3(trace_load_pred, void, i32, tl, i32)
-DEF_HELPER_3(trace_store_pred, void, i32, tl, i32)
+DEF_HELPER_2(trace_store_pred, void, i32, tl)
 
 DEF_HELPER_3(trace_load_vpred, void, i32, ptr, i32)
-DEF_HELPER_3(trace_store_vpred, void, i32, ptr, i32)
+DEF_HELPER_2(trace_store_vpred, void, i32, ptr)
 
-// special registers (USR etc.)
-// name, return type, ctrl reg, reg field, value, is_tmp
-DEF_HELPER_4(trace_store_ctrl, void, i32, i32, tl, i32)
-DEF_HELPER_4(trace_load_ctrl, void, i32, i32, tl, i32)
 #endif /* HAS_TRACEWRAP */

--- a/target/hexagon/helper.h
+++ b/target/hexagon/helper.h
@@ -110,3 +110,38 @@ DEF_HELPER_4(probe_noshuf_load, void, env, i32, int, int)
 DEF_HELPER_2(probe_pkt_scalar_store_s0, void, env, int)
 DEF_HELPER_2(probe_hvx_stores, void, env, int)
 DEF_HELPER_2(probe_pkt_scalar_hvx_stores, void, env, int)
+
+#ifdef HAS_TRACEWRAP
+// Frames
+// name, return type, (CPU env), address
+DEF_HELPER_1(trace_newframe, void, i64)
+DEF_HELPER_2(trace_endframe, void, env, i64)
+
+// Memory
+// name, return type, address, val, width
+DEF_HELPER_3(trace_load_mem, void, tl, i64, i32)
+DEF_HELPER_3(trace_store_mem, void, tl, i64, i32)
+
+// GPRs
+// name, return type, reg, val, is_tmp
+DEF_HELPER_2(trace_load_reg, void, i32, tl, i32)
+DEF_HELPER_2(trace_store_reg, void, i32, tl, i32)
+
+// VRegs
+// name, return type, vreg, val, is_tmp
+DEF_HELPER_2(trace_load_vreg, void, i32, ptr, i32)
+DEF_HELPER_2(trace_store_vreg, void, i32, ptr, i32)
+
+// Predicates
+// name, return type, pred reg, val, is_tmp
+DEF_HELPER_2(trace_load_pred, void, i32, tl, i32)
+DEF_HELPER_2(trace_store_pred, void, i32, tl, i32)
+
+DEF_HELPER_2(trace_load_vpred, void, i32, ptr, i32)
+DEF_HELPER_2(trace_store_vpred, void, i32, ptr, i32)
+
+// special registers (USR etc.)
+// name, return type, ctrl reg, reg field, value, is_tmp
+DEF_HELPER_2(trace_store_ctrl, void, i32, i32, tl, i32)
+DEF_HELPER_2(trace_load_ctrl, void, i32, i32, tl, i32)
+#endif /* HAS_TRACEWRAP */

--- a/target/hexagon/helper.h
+++ b/target/hexagon/helper.h
@@ -126,22 +126,28 @@ DEF_HELPER_3(trace_store_mem_64, void, tl, i64, i32)
 
 // GPRs
 // name, return type, reg, val, (load_new)
-DEF_HELPER_3(trace_load_reg, void, i32, i32, i32)
+DEF_HELPER_2(trace_load_reg, void, i32, i32)
+DEF_HELPER_2(trace_load_reg_new, void, i32, i32)
 DEF_HELPER_2(trace_store_reg, void, i32, i32)
-DEF_HELPER_3(trace_load_reg_pair, void, i32, i64, i32)
+
+DEF_HELPER_2(trace_load_reg_pair, void, i32, i64)
+DEF_HELPER_2(trace_load_reg_pair_new, void, i32, i64)
 DEF_HELPER_2(trace_store_reg_pair, void, i32, i64)
 
 // VRegs
 // name, return type, vreg, val, load_new
-DEF_HELPER_3(trace_load_vreg, void, i32, ptr, i32)
+DEF_HELPER_2(trace_load_vreg, void, i32, ptr)
+DEF_HELPER_2(trace_load_vreg_new, void, i32, ptr)
 DEF_HELPER_2(trace_store_vreg, void, i32, ptr)
 
 // Predicates
 // name, return type, pred reg, val, load_new
-DEF_HELPER_3(trace_load_pred, void, i32, tl, i32)
+DEF_HELPER_2(trace_load_pred, void, i32, tl)
+DEF_HELPER_2(trace_load_pred_new, void, i32, tl)
 DEF_HELPER_2(trace_store_pred, void, i32, tl)
 
-DEF_HELPER_3(trace_load_vpred, void, i32, ptr, i32)
+DEF_HELPER_2(trace_load_vpred, void, i32, ptr)
+DEF_HELPER_2(trace_load_vpred_new, void, i32, ptr)
 DEF_HELPER_2(trace_store_vpred, void, i32, ptr)
 
 #endif /* HAS_TRACEWRAP */

--- a/target/hexagon/helper.h
+++ b/target/hexagon/helper.h
@@ -114,8 +114,8 @@ DEF_HELPER_2(probe_pkt_scalar_hvx_stores, void, env, int)
 #ifdef HAS_TRACEWRAP
 // Frames
 // name, return type, (CPU env), address
-DEF_HELPER_1(trace_newframe, void, target_ulong)
-DEF_HELPER_2(trace_endframe, void, env, target_ulong, i32)
+DEF_HELPER_1(trace_newframe, void, tl)
+DEF_HELPER_3(trace_endframe, void, env, tl, i32)
 
 // Memory
 // name, return type, address, val, width
@@ -124,24 +124,24 @@ DEF_HELPER_3(trace_store_mem, void, tl, i64, i32)
 
 // GPRs
 // name, return type, reg, val, is_tmp
-DEF_HELPER_2(trace_load_reg, void, i32, tl, i32)
-DEF_HELPER_2(trace_store_reg, void, i32, tl, i32)
+DEF_HELPER_3(trace_load_reg, void, i32, tl, i32)
+DEF_HELPER_3(trace_store_reg, void, i32, tl, i32)
 
 // VRegs
 // name, return type, vreg, val, is_tmp
-DEF_HELPER_2(trace_load_vreg, void, i32, ptr, i32)
-DEF_HELPER_2(trace_store_vreg, void, i32, ptr, i32)
+DEF_HELPER_3(trace_load_vreg, void, i32, ptr, i32)
+DEF_HELPER_3(trace_store_vreg, void, i32, ptr, i32)
 
 // Predicates
 // name, return type, pred reg, val, is_tmp
-DEF_HELPER_2(trace_load_pred, void, i32, tl, i32)
-DEF_HELPER_2(trace_store_pred, void, i32, tl, i32)
+DEF_HELPER_3(trace_load_pred, void, i32, tl, i32)
+DEF_HELPER_3(trace_store_pred, void, i32, tl, i32)
 
-DEF_HELPER_2(trace_load_vpred, void, i32, ptr, i32)
-DEF_HELPER_2(trace_store_vpred, void, i32, ptr, i32)
+DEF_HELPER_3(trace_load_vpred, void, i32, ptr, i32)
+DEF_HELPER_3(trace_store_vpred, void, i32, ptr, i32)
 
 // special registers (USR etc.)
 // name, return type, ctrl reg, reg field, value, is_tmp
-DEF_HELPER_2(trace_store_ctrl, void, i32, i32, tl, i32)
-DEF_HELPER_2(trace_load_ctrl, void, i32, i32, tl, i32)
+DEF_HELPER_4(trace_store_ctrl, void, i32, i32, tl, i32)
+DEF_HELPER_4(trace_load_ctrl, void, i32, i32, tl, i32)
 #endif /* HAS_TRACEWRAP */

--- a/target/hexagon/helper.h
+++ b/target/hexagon/helper.h
@@ -129,21 +129,25 @@ DEF_HELPER_3(trace_store_mem_64, void, tl, i64, i32)
 DEF_HELPER_2(trace_load_reg, void, i32, i32)
 DEF_HELPER_2(trace_load_reg_new, void, i32, i32)
 DEF_HELPER_2(trace_store_reg, void, i32, i32)
+DEF_HELPER_2(trace_store_reg_new, void, i32, i32)
 
 // VRegs
 // name, return type, vreg, val, load_new
 DEF_HELPER_2(trace_load_vreg, void, i32, ptr)
 DEF_HELPER_2(trace_load_vreg_new, void, i32, ptr)
 DEF_HELPER_2(trace_store_vreg, void, i32, ptr)
+// DEF_HELPER_2(trace_store_vreg_new, void, i32, ptr)
 
 // Predicates
 // name, return type, pred reg, val, load_new
 DEF_HELPER_2(trace_load_pred, void, i32, tl)
 DEF_HELPER_2(trace_load_pred_new, void, i32, tl)
 DEF_HELPER_2(trace_store_pred, void, i32, tl)
+DEF_HELPER_2(trace_store_pred_new, void, i32, tl)
 
 DEF_HELPER_2(trace_load_vpred, void, i32, ptr)
 DEF_HELPER_2(trace_load_vpred_new, void, i32, ptr)
 DEF_HELPER_2(trace_store_vpred, void, i32, ptr)
+// DEF_HELPER_2(trace_store_vpred_new, void, i32, ptr)
 
 #endif /* HAS_TRACEWRAP */

--- a/target/hexagon/idef-parser/parser-helpers.c
+++ b/target/hexagon/idef-parser/parser-helpers.c
@@ -1780,14 +1780,6 @@ void gen_store(Context *c, YYLTYPE *locp, HexValue *width, HexValue *ea,
     /* Lookup the effective address EA */
     find_variable(c, locp, ea, ea);
     src_m = rvalue_materialize(c, locp, &src_m);
-    if (src_m.type == REGISTER) {
-        OUT(c, locp, "gen_helper_trace_load_reg");
-        OUT(c, locp, (src_m.reg.bit_width == 64) ? "_pair" : "");
-        OUT(c, locp, (src_m.reg.type == DOTNEW ? "_new(" : "("));
-        OUT(c, locp, "tcg_constant_i32(", &src_m.reg.id, "), ");
-        reg_print(c, locp, &src_m.reg);
-        OUT(c, locp, "));\n");
-    }
     OUT(c, locp, "gen_store", &mem_width, "(cpu_env, ", ea, ", ", &src_m);
     OUT(c, locp, ", insn->slot);\n");
 }

--- a/target/hexagon/idef-parser/parser-helpers.c
+++ b/target/hexagon/idef-parser/parser-helpers.c
@@ -1762,6 +1762,13 @@ void gen_load(Context *c, YYLTYPE *locp, HexValue *width,
         OUT(c, locp, " | MO_SIGN");
     }
     OUT(c, locp, " | MO_TE);\n");
+    OUT(c, locp, "gen_helper_trace_load_mem");
+    OUT(c, locp, (dst_bit_width == 64) ? "_64(" : "(");
+    OUT(c, locp, ea, ", ", dst, ", tcg_constant_i32(MO_", &src_bit_width);
+    if (signedness == SIGNED) {
+        OUT(c, locp, " | MO_SIGN");
+    }
+    OUT(c, locp, " | MO_TE));\n");
 }
 
 void gen_store(Context *c, YYLTYPE *locp, HexValue *width, HexValue *ea,

--- a/target/hexagon/idef-parser/parser-helpers.c
+++ b/target/hexagon/idef-parser/parser-helpers.c
@@ -1780,6 +1780,14 @@ void gen_store(Context *c, YYLTYPE *locp, HexValue *width, HexValue *ea,
     /* Lookup the effective address EA */
     find_variable(c, locp, ea, ea);
     src_m = rvalue_materialize(c, locp, &src_m);
+    if (src_m.type == REGISTER) {
+        OUT(c, locp, "gen_helper_trace_load_reg");
+        OUT(c, locp, (src_m.reg.bit_width == 64) ? "_pair" : "");
+        OUT(c, locp, (src_m.reg.type == DOTNEW ? "_new(" : "("));
+        OUT(c, locp, "tcg_constant_i32(", &src_m.reg.id, "), ");
+        reg_print(c, locp, &src_m.reg);
+        OUT(c, locp, "));\n");
+    }
     OUT(c, locp, "gen_store", &mem_width, "(cpu_env, ", ea, ", ", &src_m);
     OUT(c, locp, ", insn->slot);\n");
 }

--- a/target/hexagon/meson.build
+++ b/target/hexagon/meson.build
@@ -148,6 +148,7 @@ hexagon_ss.add(files(
     'fma_emu.c',
     'mmvec/decode_ext_mmvec.c',
     'mmvec/system_ext_mmvec.c',
+    'trace_helper.c'
 ))
 
 #

--- a/target/hexagon/op_helper.c
+++ b/target/hexagon/op_helper.c
@@ -104,15 +104,19 @@ void HELPER(commit_store)(CPUHexagonState *env, int slot_num)
     switch (width) {
     case 1:
         cpu_stb_data_ra(env, va, env->mem_log_stores[slot_num].data32, ra);
+        HELPER(trace_store_mem)(va, env->mem_log_stores[slot_num].data32, width);
         break;
     case 2:
         cpu_stw_data_ra(env, va, env->mem_log_stores[slot_num].data32, ra);
+        HELPER(trace_store_mem)(va, env->mem_log_stores[slot_num].data32, width);
         break;
     case 4:
         cpu_stl_data_ra(env, va, env->mem_log_stores[slot_num].data32, ra);
+        HELPER(trace_store_mem)(va, env->mem_log_stores[slot_num].data32, width);
         break;
     case 8:
         cpu_stq_data_ra(env, va, env->mem_log_stores[slot_num].data64, ra);
+        HELPER(trace_store_mem_64)(va, env->mem_log_stores[slot_num].data64, width);
         break;
     default:
         g_assert_not_reached();
@@ -581,7 +585,9 @@ uint8_t mem_load1(CPUHexagonState *env, bool pkt_has_store_s1,
 {
     uintptr_t ra = GETPC();
     check_noshuf(env, pkt_has_store_s1, slot, vaddr, 1);
-    return cpu_ldub_data_ra(env, vaddr, ra);
+    uint8_t val = cpu_ldub_data_ra(env, vaddr, ra);
+    HELPER(trace_load_mem)(vaddr, val, 1);
+    return val;
 }
 
 uint16_t mem_load2(CPUHexagonState *env, bool pkt_has_store_s1,
@@ -589,7 +595,9 @@ uint16_t mem_load2(CPUHexagonState *env, bool pkt_has_store_s1,
 {
     uintptr_t ra = GETPC();
     check_noshuf(env, pkt_has_store_s1, slot, vaddr, 2);
-    return cpu_lduw_data_ra(env, vaddr, ra);
+    uint16_t val = cpu_lduw_data_ra(env, vaddr, ra);
+    HELPER(trace_load_mem)(vaddr, val, 2);
+    return val;
 }
 
 uint32_t mem_load4(CPUHexagonState *env, bool pkt_has_store_s1,
@@ -597,7 +605,9 @@ uint32_t mem_load4(CPUHexagonState *env, bool pkt_has_store_s1,
 {
     uintptr_t ra = GETPC();
     check_noshuf(env, pkt_has_store_s1, slot, vaddr, 4);
-    return cpu_ldl_data_ra(env, vaddr, ra);
+    uint32_t val = cpu_ldl_data_ra(env, vaddr, ra);
+    HELPER(trace_load_mem)(vaddr, val, 4);
+    return val;
 }
 
 uint64_t mem_load8(CPUHexagonState *env, bool pkt_has_store_s1,
@@ -605,7 +615,9 @@ uint64_t mem_load8(CPUHexagonState *env, bool pkt_has_store_s1,
 {
     uintptr_t ra = GETPC();
     check_noshuf(env, pkt_has_store_s1, slot, vaddr, 8);
-    return cpu_ldq_data_ra(env, vaddr, ra);
+    uint64_t val = cpu_ldq_data_ra(env, vaddr, ra);
+    HELPER(trace_load_mem_64)(vaddr, val, 8);
+    return val;
 }
 
 /* Floating point */

--- a/target/hexagon/op_helper.c
+++ b/target/hexagon/op_helper.c
@@ -104,19 +104,19 @@ void HELPER(commit_store)(CPUHexagonState *env, int slot_num)
     switch (width) {
     case 1:
         cpu_stb_data_ra(env, va, env->mem_log_stores[slot_num].data32, ra);
-        HELPER(trace_store_mem)(va, env->mem_log_stores[slot_num].data32, width);
+        HELPER(trace_store_mem)(va, env->mem_log_stores[slot_num].data32, size_memop(width));
         break;
     case 2:
         cpu_stw_data_ra(env, va, env->mem_log_stores[slot_num].data32, ra);
-        HELPER(trace_store_mem)(va, env->mem_log_stores[slot_num].data32, width);
+        HELPER(trace_store_mem)(va, env->mem_log_stores[slot_num].data32, size_memop(width));
         break;
     case 4:
         cpu_stl_data_ra(env, va, env->mem_log_stores[slot_num].data32, ra);
-        HELPER(trace_store_mem)(va, env->mem_log_stores[slot_num].data32, width);
+        HELPER(trace_store_mem)(va, env->mem_log_stores[slot_num].data32, size_memop(width));
         break;
     case 8:
         cpu_stq_data_ra(env, va, env->mem_log_stores[slot_num].data64, ra);
-        HELPER(trace_store_mem_64)(va, env->mem_log_stores[slot_num].data64, width);
+        HELPER(trace_store_mem_64)(va, env->mem_log_stores[slot_num].data64, size_memop(width));
         break;
     default:
         g_assert_not_reached();
@@ -586,7 +586,7 @@ uint8_t mem_load1(CPUHexagonState *env, bool pkt_has_store_s1,
     uintptr_t ra = GETPC();
     check_noshuf(env, pkt_has_store_s1, slot, vaddr, 1);
     uint8_t val = cpu_ldub_data_ra(env, vaddr, ra);
-    HELPER(trace_load_mem)(vaddr, val, 1);
+    HELPER(trace_load_mem)(vaddr, val, MO_8);
     return val;
 }
 
@@ -596,7 +596,7 @@ uint16_t mem_load2(CPUHexagonState *env, bool pkt_has_store_s1,
     uintptr_t ra = GETPC();
     check_noshuf(env, pkt_has_store_s1, slot, vaddr, 2);
     uint16_t val = cpu_lduw_data_ra(env, vaddr, ra);
-    HELPER(trace_load_mem)(vaddr, val, 2);
+    HELPER(trace_load_mem)(vaddr, val, MO_16);
     return val;
 }
 
@@ -606,7 +606,7 @@ uint32_t mem_load4(CPUHexagonState *env, bool pkt_has_store_s1,
     uintptr_t ra = GETPC();
     check_noshuf(env, pkt_has_store_s1, slot, vaddr, 4);
     uint32_t val = cpu_ldl_data_ra(env, vaddr, ra);
-    HELPER(trace_load_mem)(vaddr, val, 4);
+    HELPER(trace_load_mem)(vaddr, val, MO_32);
     return val;
 }
 
@@ -616,7 +616,7 @@ uint64_t mem_load8(CPUHexagonState *env, bool pkt_has_store_s1,
     uintptr_t ra = GETPC();
     check_noshuf(env, pkt_has_store_s1, slot, vaddr, 8);
     uint64_t val = cpu_ldq_data_ra(env, vaddr, ra);
-    HELPER(trace_load_mem_64)(vaddr, val, 8);
+    HELPER(trace_load_mem_64)(vaddr, val, size_memop(8));
     return val;
 }
 

--- a/target/hexagon/trace_helper.c
+++ b/target/hexagon/trace_helper.c
@@ -2,19 +2,6 @@
 
 #include "trace_helper.h"
 
-#ifdef BSWAP_NEEDED
-static void memcpy_rev(void *dest, const void *src, size_t size) {
-  if (size < 1) {
-    return;
-  }
-  const char *s = src;
-  char *d = dest;
-  for (size_t i = 0, j = size - 1; i < size; --j, ++i) {
-    d[i] = s[j];
-  }
-}
-#endif
-
 // Copies from genptr
 
 const char * const hex_regnames[TOTAL_PER_THREAD_REGS] = {

--- a/target/hexagon/trace_helper.c
+++ b/target/hexagon/trace_helper.c
@@ -170,33 +170,6 @@ void HELPER(trace_store_reg)(uint32_t reg, uint32_t val) {
   qemu_trace_add_operand(oi, 0x2);
 }
 
-void HELPER(trace_load_reg_pair)(uint32_t reg, uint64_t val) {
-  assert(reg + 1 < sizeof(hex_regnames)/sizeof(hex_regnames[0]));
-  qemu_log("TRACE \tLOAD REG %s:%s Val: 0x%lx\n", hex_regnames[reg+1], &hex_regnames[reg][1], val);
-  char reg_name[16] = { 0 };
-  snprintf(reg_name, sizeof(reg_name) - 1, "%s:%s", hex_regnames[reg+1], &hex_regnames[reg][1]);
-  OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS/8);
-  qemu_trace_add_operand(oi, 0x1);
-}
-
-void HELPER(trace_load_reg_pair_new)(uint32_t reg, uint64_t val) {
-  assert(reg + 1 < sizeof(hex_regnames)/sizeof(hex_regnames[0]));
-  qemu_log("TRACE \tLOAD REG NEW %s:%s Val: 0x%lx\n", hex_regnames[reg+1], &hex_regnames[reg][1], val);
-  char reg_name[16] = { 0 };
-  snprintf(reg_name, sizeof(reg_name) - 1, "%s:%s_tmp", hex_regnames[reg+1], &hex_regnames[reg][1]);
-  OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS/8);
-  qemu_trace_add_operand(oi, 0x1);
-}
-
-void HELPER(trace_store_reg_pair)(uint32_t reg, uint64_t val) {
-  assert(reg + 1 < sizeof(hex_regnames)/sizeof(hex_regnames[0]));
-  qemu_log("TRACE \tSTORE REG %s:%s Val: 0x%lx\n", hex_regnames[reg+1], &hex_regnames[reg][1], val);
-  char reg_name[16] = { 0 };
-  snprintf(reg_name, sizeof(reg_name) - 1, "%s:%s_tmp", hex_regnames[reg+1], &hex_regnames[reg][1]);
-  OperandInfo *oi = build_load_store_reg_op(reg_name, 1, &val, TARGET_LONG_BITS/8);
-  qemu_trace_add_operand(oi, 0x2);
-}
-
 // Predicates
 // name, return type, pred reg, val
 void HELPER(trace_load_pred)(uint32_t pred, target_ulong val) {

--- a/target/hexagon/trace_helper.c
+++ b/target/hexagon/trace_helper.c
@@ -47,35 +47,35 @@ static const char * const hexagon_prednames[] = {
  * data_size Size of the data in bytes. \return OperandInfo* Pointer to the
  * operand for a BAP frame.
  */
-// static OperandInfo *build_load_store_reg_op(const char *name, int ls,
-//                                             const void *data,
-//                                             size_t data_size) {
-//   RegOperand *ro = g_new(RegOperand, 1);
-//   reg_operand__init(ro);
-//   ro->name = strdup(name);
+static OperandInfo *build_load_store_reg_op(const char *name, int ls,
+                                            const void *data,
+                                            size_t data_size) {
+  RegOperand *ro = g_new(RegOperand, 1);
+  reg_operand__init(ro);
+  ro->name = strdup(name);
 
-//   OperandInfoSpecific *ois = g_new(OperandInfoSpecific, 1);
-//   operand_info_specific__init(ois);
-//   ois->reg_operand = ro;
+  OperandInfoSpecific *ois = g_new(OperandInfoSpecific, 1);
+  operand_info_specific__init(ois);
+  ois->reg_operand = ro;
 
-//   OperandUsage *ou = g_new(OperandUsage, 1);
-//   operand_usage__init(ou);
-//   if (ls == 0) {
-//     ou->read = 1;
-//   } else {
-//     ou->written = 1;
-//   }
-//   OperandInfo *oi = g_new(OperandInfo, 1);
-//   operand_info__init(oi);
-//   oi->bit_length = 0;
-//   oi->operand_info_specific = ois;
-//   oi->operand_usage = ou;
-//   oi->value.len = data_size;
-//   oi->value.data = g_malloc(oi->value.len);
-//   memcpy(oi->value.data, data, data_size);
+  OperandUsage *ou = g_new(OperandUsage, 1);
+  operand_usage__init(ou);
+  if (ls == 0) {
+    ou->read = 1;
+  } else {
+    ou->written = 1;
+  }
+  OperandInfo *oi = g_new(OperandInfo, 1);
+  operand_info__init(oi);
+  oi->bit_length = 0;
+  oi->operand_info_specific = ois;
+  oi->operand_usage = ou;
+  oi->value.len = data_size;
+  oi->value.data = g_malloc(oi->value.len);
+  memcpy(oi->value.data, data, data_size);
 
-//   return oi;
-// }
+  return oi;
+}
 
 static OperandInfo *build_load_store_mem(uint64_t addr, int ls, const void *data,
                             size_t data_size) {
@@ -157,23 +157,29 @@ void HELPER(trace_store_mem_64)(target_ulong addr, uint64_t val, MemOp op) {
 }
 
 // GPRs
-// name, return type, reg, val, load_new
 void HELPER(trace_load_reg)(uint32_t reg, uint32_t val) {
+  assert(reg < sizeof(hexagon_regnames)/sizeof(hex_regnames[0]));
   qemu_log("TRACE \tLOAD REG %s Val: 0x%x\n", hexagon_regnames[reg], val);
-  // OperandInfo *oi = build_load_store_reg_op(reg, val, 0, load_new);
-  // qemu_trace_add_operand(oi, 0x1);
+  OperandInfo *oi = build_load_store_reg_op(hexagon_regnames[reg], 0, &val, TARGET_LONG_BITS);
+  qemu_trace_add_operand(oi, 0x1);
 }
 
 void HELPER(trace_load_reg_new)(uint32_t reg, uint32_t val) {
+  assert(reg < sizeof(hexagon_regnames)/sizeof(hex_regnames[0]));
   qemu_log("TRACE \tLOAD REG NEW %s Val: 0x%x\n", hexagon_regnames[reg], val);
-  // OperandInfo *oi = build_load_store_reg_op(reg, val, 0, load_new);
-  // qemu_trace_add_operand(oi, 0x1);
+  char reg_name[16] = { 0 };
+  snprintf(reg_name, sizeof(reg_name) - 1, "%s_tmp", hexagon_regnames[reg]);
+  OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS);
+  qemu_trace_add_operand(oi, 0x1);
 }
 
 void HELPER(trace_store_reg)(uint32_t reg, uint32_t val) {
+  assert(reg < sizeof(hexagon_regnames)/sizeof(hex_regnames[0]));
   qemu_log("TRACE \tSTORE REG %s Val: 0x%x\n", hexagon_regnames[reg], val);
-  // OperandInfo *oi = load_store_reg(reg, val, 1);
-  // qemu_trace_add_operand(oi, 0x2);
+  char reg_name[16] = { 0 };
+  snprintf(reg_name, sizeof(reg_name) - 1, "%s_tmp", hexagon_regnames[reg]);
+  OperandInfo *oi = build_load_store_reg_op(reg_name, 1, &val, TARGET_LONG_BITS);
+  qemu_trace_add_operand(oi, 0x2);
 }
 
 void HELPER(trace_load_reg_pair)(uint32_t reg, uint64_t val) {

--- a/target/hexagon/trace_helper.c
+++ b/target/hexagon/trace_helper.c
@@ -154,19 +154,26 @@ void HELPER(trace_load_reg)(uint32_t reg, uint32_t val) {
 
 void HELPER(trace_load_reg_new)(uint32_t reg, uint32_t val) {
   assert(reg < sizeof(hex_regnames)/sizeof(hex_regnames[0]));
-  qemu_log("TRACE \tLOAD REG NEW %s Val: 0x%x\n", hex_regnames[reg], val);
+  qemu_log("TRACE \tLOAD REG %s.new Val: 0x%x\n", hex_regnames[reg], val);
   char reg_name[16] = { 0 };
   snprintf(reg_name, sizeof(reg_name) - 1, "%s_tmp", hex_regnames[reg]);
   OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS/8);
   qemu_trace_add_operand(oi, 0x1);
 }
 
-void HELPER(trace_store_reg)(uint32_t reg, uint32_t val) {
+void HELPER(trace_store_reg_new)(uint32_t reg, uint32_t val) {
   assert(reg < sizeof(hex_regnames)/sizeof(hex_regnames[0]));
-  qemu_log("TRACE \tSTORE REG %s Val: 0x%x\n", hex_regnames[reg], val);
+  qemu_log("TRACE \tSTORE REG %s.new Val: 0x%x\n", hex_regnames[reg], val);
   char reg_name[16] = { 0 };
   snprintf(reg_name, sizeof(reg_name) - 1, "%s_tmp", hex_regnames[reg]);
   OperandInfo *oi = build_load_store_reg_op(reg_name, 1, &val, TARGET_LONG_BITS/8);
+  qemu_trace_add_operand(oi, 0x2);
+}
+
+void HELPER(trace_store_reg)(uint32_t reg, uint32_t val) {
+  assert(reg < sizeof(hex_regnames)/sizeof(hex_regnames[0]));
+  qemu_log("TRACE \tSTORE REG %s Val: 0x%x\n", hex_regnames[reg], val);
+  OperandInfo *oi = build_load_store_reg_op(hex_regnames[reg], 1, &val, TARGET_LONG_BITS/8);
   qemu_trace_add_operand(oi, 0x2);
 }
 
@@ -181,7 +188,7 @@ void HELPER(trace_load_pred)(uint32_t pred, target_ulong val) {
 
 void HELPER(trace_load_pred_new)(uint32_t pred, target_ulong val) {
   assert(pred < sizeof(hexagon_prednames)/sizeof(hexagon_prednames[0]));
-  qemu_log("TRACE \tLOAD PRED NEW: %s Val: 0x%x\n", hexagon_prednames[pred], val);
+  qemu_log("TRACE \tLOAD PRED: %s.new Val: 0x%x\n", hexagon_prednames[pred], val);
   char pred_name[16] = { 0 };
   snprintf(pred_name, sizeof(pred_name) - 1, "%s_tmp", hexagon_prednames[pred]);
   OperandInfo *oi = build_load_store_reg_op(pred_name, 0, &val, 1);
@@ -191,6 +198,13 @@ void HELPER(trace_load_pred_new)(uint32_t pred, target_ulong val) {
 void HELPER(trace_store_pred)(uint32_t pred, target_ulong val) {
   assert(pred < sizeof(hexagon_prednames)/sizeof(hexagon_prednames[0]));
   qemu_log("TRACE \tSTORE PRED: %s Val: 0x%x\n", hexagon_prednames[pred], val);
+  OperandInfo *oi = build_load_store_reg_op(hexagon_prednames[pred], 1, &val, 1);
+  qemu_trace_add_operand(oi, 0x2);
+}
+
+void HELPER(trace_store_pred_new)(uint32_t pred, target_ulong val) {
+  assert(pred < sizeof(hexagon_prednames)/sizeof(hexagon_prednames[0]));
+  qemu_log("TRACE \tSTORE PRED: %s.new Val: 0x%x\n", hexagon_prednames[pred], val);
   char pred_name[16] = { 0 };
   snprintf(pred_name, sizeof(pred_name) - 1, "%s_tmp", hexagon_prednames[pred]);
   OperandInfo *oi = build_load_store_reg_op(pred_name, 1, &val, 1);

--- a/target/hexagon/trace_helper.c
+++ b/target/hexagon/trace_helper.c
@@ -97,9 +97,13 @@ static OperandInfo *build_load_store_mem(uint64_t addr, int ls, const void *data
  * QEMUs helper.
  */
 
-void HELPER(trace_newframe)(target_ulong addr) { qemu_trace_newframe(addr, 0); }
+void HELPER(trace_newframe)(target_ulong addr) {
+  qemu_log("FRAME BEGIN at 0x%x\n", addr);
+  qemu_trace_newframe(addr, 0);
+}
 void HELPER(trace_endframe)(CPUHexagonState *state, target_ulong addr,
                             uint32_t pkt_size) {
+  qemu_log("FRAME END at 0x%x size: %d\n", addr, pkt_size);
   qemu_trace_endframe(state, addr, pkt_size);
 }
 
@@ -120,14 +124,26 @@ void HELPER(trace_store_mem)(target_ulong addr, uint64_t val, uint32_t width) {
 
 // GPRs
 // name, return type, reg, val, is_tmp
-void HELPER(trace_load_reg)(uint32_t reg, target_ulong val, uint32_t is_tmp) {
+void HELPER(trace_load_reg)(uint32_t reg, uint32_t val, uint32_t is_tmp) {
   qemu_log("LOAD REG %d Val: 0x%x TMP: %d\n", reg, val, is_tmp);
   // OperandInfo *oi = build_load_store_reg_op(reg, val, 0, is_tmp);
   // qemu_trace_add_operand(oi, 0x1);
 }
 
-void HELPER(trace_store_reg)(uint32_t reg, target_ulong val, uint32_t is_tmp) {
+void HELPER(trace_store_reg)(uint32_t reg, uint32_t val, uint32_t is_tmp) {
   qemu_log("STORE REG %d Val: 0x%x TMP: %d\n", reg, val, is_tmp);
+  // OperandInfo *oi = load_store_reg(reg, val, 1);
+  // qemu_trace_add_operand(oi, 0x2);
+}
+
+void HELPER(trace_load_reg_pair)(uint32_t reg, uint64_t val, uint32_t is_tmp) {
+  qemu_log("LOAD REG %d Val: 0x%lx TMP: %d\n", reg, val, is_tmp);
+  // OperandInfo *oi = build_load_store_reg_op(reg, val, 0, is_tmp);
+  // qemu_trace_add_operand(oi, 0x1);
+}
+
+void HELPER(trace_store_reg_pair)(uint32_t reg, uint64_t val, uint32_t is_tmp) {
+  qemu_log("STORE REG %d Val: 0x%lx TMP: %d\n", reg, val, is_tmp);
   // OperandInfo *oi = load_store_reg(reg, val, 1);
   // qemu_trace_add_operand(oi, 0x2);
 }

--- a/target/hexagon/trace_helper.c
+++ b/target/hexagon/trace_helper.c
@@ -108,8 +108,8 @@ void HELPER(trace_newframe)(target_ulong addr) {
 }
 void HELPER(trace_endframe)(CPUHexagonState *state, target_ulong addr,
                             uint32_t pkt_size) {
-  qemu_log("TRACE FRAME END at 0x%x size: %d\n", addr, pkt_size);
-  qemu_trace_endframe(state, addr, pkt_size);
+  qemu_log("TRACE FRAME END at 0x%x size: %d\n", addr, pkt_size * 4);
+  qemu_trace_endframe(state, addr, pkt_size * 4);
 }
 
 // Memory

--- a/target/hexagon/trace_helper.c
+++ b/target/hexagon/trace_helper.c
@@ -126,26 +126,30 @@ void HELPER(trace_endframe)(CPUHexagonState *state, target_ulong addr,
 
 // Memory
 // name, return type, address, val, width
-void HELPER(trace_load_mem)(target_ulong addr, target_ulong val, uint32_t width) {
+void HELPER(trace_load_mem)(target_ulong addr, target_ulong val, MemOp op) {
+  uint32_t width = memop_size(op);
   qemu_log("TRACE \tLOAD MEM at 0x%x width: %d data: 0x%x\n", addr, width, val);
   OperandInfo *oi = build_load_store_mem(addr, 0, &val, width);
   qemu_trace_add_operand(oi, 0x1);
 }
 
-void HELPER(trace_store_mem)(target_ulong addr, target_ulong val, uint32_t width) {
+void HELPER(trace_store_mem)(target_ulong addr, target_ulong val, MemOp op) {
+  uint32_t width = memop_size(op);
   qemu_log("TRACE \tSTORE MEM at 0x%x width: %d data: 0x%lx\n", addr, width,
            (unsigned long)val);
   OperandInfo *oi = build_load_store_mem(addr, 1, &val, width);
   qemu_trace_add_operand(oi, 0x2);
 }
 
-void HELPER(trace_load_mem_64)(target_ulong addr, uint64_t val, uint32_t width) {
+void HELPER(trace_load_mem_64)(target_ulong addr, uint64_t val, MemOp op) {
+  uint32_t width = memop_size(op);
   qemu_log("TRACE \tLOAD MEM at 0x%x width: %d data: 0x%lx\n", addr, width, val);
   OperandInfo *oi = build_load_store_mem(addr, 0, &val, width);
   qemu_trace_add_operand(oi, 0x1);
 }
 
-void HELPER(trace_store_mem_64)(target_ulong addr, uint64_t val, uint32_t width) {
+void HELPER(trace_store_mem_64)(target_ulong addr, uint64_t val, MemOp op) {
+  uint32_t width = memop_size(op);
   qemu_log("TRACE \tSTORE MEM at 0x%lx width: %d data: 0x%lx\n", (unsigned long)addr, width,
            (unsigned long)val);
   OperandInfo *oi = build_load_store_mem(addr, 1, &val, width);

--- a/target/hexagon/trace_helper.c
+++ b/target/hexagon/trace_helper.c
@@ -98,38 +98,38 @@ static OperandInfo *build_load_store_mem(uint64_t addr, int ls, const void *data
  */
 
 void HELPER(trace_newframe)(target_ulong addr) {
-  qemu_log("FRAME BEGIN at 0x%x\n", addr);
+  qemu_log("TRACE FRAME BEGIN at 0x%x\n", addr);
   qemu_trace_newframe(addr, 0);
 }
 void HELPER(trace_endframe)(CPUHexagonState *state, target_ulong addr,
                             uint32_t pkt_size) {
-  qemu_log("FRAME END at 0x%x size: %d\n", addr, pkt_size);
+  qemu_log("TRACE FRAME END at 0x%x size: %d\n", addr, pkt_size);
   qemu_trace_endframe(state, addr, pkt_size);
 }
 
 // Memory
 // name, return type, address, val, width
 void HELPER(trace_load_mem)(target_ulong addr, target_ulong val, uint32_t width) {
-  qemu_log("\tLOAD at 0x%x width: %d data: 0x%x\n", addr, width, val);
+  qemu_log("TRACE \tLOAD MEM at 0x%x width: %d data: 0x%x\n", addr, width, val);
   OperandInfo *oi = build_load_store_mem(addr, 0, &val, width);
   qemu_trace_add_operand(oi, 0x1);
 }
 
 void HELPER(trace_store_mem)(target_ulong addr, target_ulong val, uint32_t width) {
-  qemu_log("\tSTORE at 0x%x width: %d data: 0x%lx\n", addr, width,
+  qemu_log("TRACE \tSTORE MEM at 0x%x width: %d data: 0x%lx\n", addr, width,
            (unsigned long)val);
   OperandInfo *oi = build_load_store_mem(addr, 1, &val, width);
   qemu_trace_add_operand(oi, 0x2);
 }
 
 void HELPER(trace_load_mem_64)(target_ulong addr, uint64_t val, uint32_t width) {
-  qemu_log("\tLOAD at 0x%x width: %d data: 0x%lx\n", addr, width, val);
+  qemu_log("TRACE \tLOAD MEM at 0x%x width: %d data: 0x%lx\n", addr, width, val);
   OperandInfo *oi = build_load_store_mem(addr, 0, &val, width);
   qemu_trace_add_operand(oi, 0x1);
 }
 
 void HELPER(trace_store_mem_64)(target_ulong addr, uint64_t val, uint32_t width) {
-  qemu_log("\tSTORE at 0x%lx width: %d data: 0x%lx\n", (unsigned long)addr, width,
+  qemu_log("TRACE \tSTORE MEM at 0x%lx width: %d data: 0x%lx\n", (unsigned long)addr, width,
            (unsigned long)val);
   OperandInfo *oi = build_load_store_mem(addr, 1, &val, width);
   qemu_trace_add_operand(oi, 0x2);
@@ -137,54 +137,78 @@ void HELPER(trace_store_mem_64)(target_ulong addr, uint64_t val, uint32_t width)
 
 // GPRs
 // name, return type, reg, val, load_new
-void HELPER(trace_load_reg)(uint32_t reg, uint32_t val, uint32_t load_new) {
-  qemu_log("\tLOAD REG %d Val: 0x%x TMP: %d\n", reg, val, load_new);
+void HELPER(trace_load_reg)(uint32_t reg, uint32_t val) {
+  qemu_log("TRACE \tLOAD REG %d Val: 0x%x\n", reg, val);
+  // OperandInfo *oi = build_load_store_reg_op(reg, val, 0, load_new);
+  // qemu_trace_add_operand(oi, 0x1);
+}
+
+void HELPER(trace_load_reg_new)(uint32_t reg, uint32_t val) {
+  qemu_log("TRACE \tLOAD REG NEW %d Val: 0x%x\n", reg, val);
   // OperandInfo *oi = build_load_store_reg_op(reg, val, 0, load_new);
   // qemu_trace_add_operand(oi, 0x1);
 }
 
 void HELPER(trace_store_reg)(uint32_t reg, uint32_t val) {
-  qemu_log("\tSTORE REG %d Val: 0x%x\n", reg, val);
+  qemu_log("TRACE \tSTORE REG %d Val: 0x%x\n", reg, val);
   // OperandInfo *oi = load_store_reg(reg, val, 1);
   // qemu_trace_add_operand(oi, 0x2);
 }
 
-void HELPER(trace_load_reg_pair)(uint32_t reg, uint64_t val, uint32_t load_new) {
-  qemu_log("\tLOAD REG %d Val: 0x%lx TMP: %d\n", reg, val, load_new);
+void HELPER(trace_load_reg_pair)(uint32_t reg, uint64_t val) {
+  qemu_log("TRACE \tLOAD REG %d Val: 0x%lx\n", reg, val);
+  // OperandInfo *oi = build_load_store_reg_op(reg, val, 0, load_new);
+  // qemu_trace_add_operand(oi, 0x1);
+}
+
+void HELPER(trace_load_reg_pair_new)(uint32_t reg, uint64_t val) {
+  qemu_log("TRACE \tLOAD REG NEW %d Val: 0x%lx\n", reg, val);
   // OperandInfo *oi = build_load_store_reg_op(reg, val, 0, load_new);
   // qemu_trace_add_operand(oi, 0x1);
 }
 
 void HELPER(trace_store_reg_pair)(uint32_t reg, uint64_t val) {
-  qemu_log("\tSTORE REG %d Val: 0x%lx\n", reg, val);
+  qemu_log("TRACE \tSTORE REG %d Val: 0x%lx\n", reg, val);
   // OperandInfo *oi = load_store_reg(reg, val, 1);
   // qemu_trace_add_operand(oi, 0x2);
 }
 
 // VRegs
 // name, return type, vreg, val, load_new
-void HELPER(trace_load_vreg)(uint32_t vreg, void *val, uint32_t load_new) {
-  qemu_log("\tLOAD VREG %d Val: %p TMP: %d\n", vreg, val, load_new);
+void HELPER(trace_load_vreg)(uint32_t vreg, void *val) {
+  qemu_log("TRACE \tLOAD VREG: %d Val: %p\n", vreg, val);
+}
+
+void HELPER(trace_load_vreg_new)(uint32_t vreg, void *val) {
+  qemu_log("TRACE \tLOAD VREG NEW: %d Val: %p\n", vreg, val);
 }
 
 void HELPER(trace_store_vreg)(uint32_t vreg, void *val) {
-  qemu_log("\tSTORE VREG %d Val: %p\n", vreg, val);
+  qemu_log("TRACE \tSTORE VREG %d Val: %p\n", vreg, val);
 }
 
 // Predicates
 // name, return type, pred reg, val, load_new
-void HELPER(trace_load_pred)(uint32_t pred, target_ulong val, uint32_t load_new) {
-  qemu_log("\tLOAD PRED %d Val: 0x%x TMP: %d\n", pred, val, load_new);
+void HELPER(trace_load_pred)(uint32_t pred, target_ulong val) {
+  qemu_log("TRACE \tLOAD PRED %d Val: 0x%x\n", pred, val);
+}
+
+void HELPER(trace_load_pred_new)(uint32_t pred, target_ulong val) {
+  qemu_log("TRACE \tLOAD PRED NEW: %d Val: 0x%x\n", pred, val);
 }
 
 void HELPER(trace_store_pred)(uint32_t pred, target_ulong val) {
-  qemu_log("\tSTORE PRED %d Val: 0x%x\n", pred, val);
+  qemu_log("TRACE \tSTORE PRED: %d Val: 0x%x\n", pred, val);
 }
 
-void HELPER(trace_load_vpred)(uint32_t vpred, void *val, uint32_t load_new) {
-  qemu_log("\tLOAD VPRED %d Val: %p TMP: %d\n", vpred, val, load_new);
+void HELPER(trace_load_vpred)(uint32_t vpred, void *val) {
+  qemu_log("TRACE \tLOAD VPRED %d Val: %p\n", vpred, val);
+}
+
+void HELPER(trace_load_vpred_new)(uint32_t vpred, void *val) {
+  qemu_log("TRACE \tLOAD VPRED NEW: %d Val: %p\n", vpred, val);
 }
 
 void HELPER(trace_store_vpred)(uint32_t vpred, void *val) {
-  qemu_log("\tSTORE VPRED %d Val: %p\n", vpred, val);
+  qemu_log("TRACE \tSTORE VPRED: %d Val: %p\n", vpred, val);
 }

--- a/target/hexagon/trace_helper.c
+++ b/target/hexagon/trace_helper.c
@@ -109,13 +109,26 @@ void HELPER(trace_endframe)(CPUHexagonState *state, target_ulong addr,
 
 // Memory
 // name, return type, address, val, width
-void HELPER(trace_load_mem)(target_ulong addr, uint64_t val, uint32_t width) {
+void HELPER(trace_load_mem)(target_ulong addr, target_ulong val, uint32_t width) {
+  qemu_log("\tLOAD at 0x%x width: %d data: 0x%x\n", addr, width, val);
+  OperandInfo *oi = build_load_store_mem(addr, 0, &val, width);
+  qemu_trace_add_operand(oi, 0x1);
+}
+
+void HELPER(trace_store_mem)(target_ulong addr, target_ulong val, uint32_t width) {
+  qemu_log("\tSTORE at 0x%x width: %d data: 0x%lx\n", addr, width,
+           (unsigned long)val);
+  OperandInfo *oi = build_load_store_mem(addr, 1, &val, width);
+  qemu_trace_add_operand(oi, 0x2);
+}
+
+void HELPER(trace_load_mem_64)(target_ulong addr, uint64_t val, uint32_t width) {
   qemu_log("\tLOAD at 0x%x width: %d data: 0x%lx\n", addr, width, val);
   OperandInfo *oi = build_load_store_mem(addr, 0, &val, width);
   qemu_trace_add_operand(oi, 0x1);
 }
 
-void HELPER(trace_store_mem)(target_ulong addr, uint64_t val, uint32_t width) {
+void HELPER(trace_store_mem_64)(target_ulong addr, uint64_t val, uint32_t width) {
   qemu_log("\tSTORE at 0x%lx width: %d data: 0x%lx\n", (unsigned long)addr, width,
            (unsigned long)val);
   OperandInfo *oi = build_load_store_mem(addr, 1, &val, width);

--- a/target/hexagon/trace_helper.c
+++ b/target/hexagon/trace_helper.c
@@ -214,22 +214,8 @@ void HELPER(trace_store_reg_pair)(uint32_t reg, uint64_t val) {
   qemu_trace_add_operand(oi, 0x2);
 }
 
-// VRegs
-// name, return type, vreg, val, load_new
-void HELPER(trace_load_vreg)(uint32_t vreg, void *val) {
-  qemu_log("TRACE \tLOAD VREG: %d Val: %p\n", vreg, val);
-}
-
-void HELPER(trace_load_vreg_new)(uint32_t vreg, void *val) {
-  qemu_log("TRACE \tLOAD VREG NEW: %d Val: %p\n", vreg, val);
-}
-
-void HELPER(trace_store_vreg)(uint32_t vreg, void *val) {
-  qemu_log("TRACE \tSTORE VREG %d Val: %p\n", vreg, val);
-}
-
 // Predicates
-// name, return type, pred reg, val, load_new
+// name, return type, pred reg, val
 void HELPER(trace_load_pred)(uint32_t pred, target_ulong val) {
   assert(pred < sizeof(hexagon_prednames)/sizeof(hexagon_prednames[0]));
   qemu_log("TRACE \tLOAD PRED %s Val: 0x%x\n", hexagon_prednames[pred], val);
@@ -253,6 +239,20 @@ void HELPER(trace_store_pred)(uint32_t pred, target_ulong val) {
   snprintf(pred_name, sizeof(pred_name) - 1, "%s_tmp", hexagon_prednames[pred]);
   OperandInfo *oi = build_load_store_reg_op(pred_name, 1, &val, 1);
   qemu_trace_add_operand(oi, 0x2);
+}
+
+// VRegs
+// name, return type, vreg, val
+void HELPER(trace_load_vreg)(uint32_t vreg, void *val) {
+  qemu_log("TRACE \tLOAD VREG: %d Val: %p\n", vreg, val);
+}
+
+void HELPER(trace_load_vreg_new)(uint32_t vreg, void *val) {
+  qemu_log("TRACE \tLOAD VREG NEW: %d Val: %p\n", vreg, val);
+}
+
+void HELPER(trace_store_vreg)(uint32_t vreg, void *val) {
+  qemu_log("TRACE \tSTORE VREG %d Val: %p\n", vreg, val);
 }
 
 void HELPER(trace_load_vpred)(uint32_t vpred, void *val) {

--- a/target/hexagon/trace_helper.c
+++ b/target/hexagon/trace_helper.c
@@ -165,7 +165,7 @@ void HELPER(trace_store_mem_64)(target_ulong addr, uint64_t val, MemOp op) {
 void HELPER(trace_load_reg)(uint32_t reg, uint32_t val) {
   assert(reg < sizeof(hex_regnames)/sizeof(hex_regnames[0]));
   qemu_log("TRACE \tLOAD REG %s Val: 0x%x\n", hex_regnames[reg], val);
-  OperandInfo *oi = build_load_store_reg_op(hex_regnames[reg], 0, &val, TARGET_LONG_BITS);
+  OperandInfo *oi = build_load_store_reg_op(hex_regnames[reg], 0, &val, TARGET_LONG_BITS/4);
   qemu_trace_add_operand(oi, 0x1);
 }
 
@@ -174,7 +174,7 @@ void HELPER(trace_load_reg_new)(uint32_t reg, uint32_t val) {
   qemu_log("TRACE \tLOAD REG NEW %s Val: 0x%x\n", hex_regnames[reg], val);
   char reg_name[16] = { 0 };
   snprintf(reg_name, sizeof(reg_name) - 1, "%s_tmp", hex_regnames[reg]);
-  OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS);
+  OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS/4);
   qemu_trace_add_operand(oi, 0x1);
 }
 
@@ -183,7 +183,7 @@ void HELPER(trace_store_reg)(uint32_t reg, uint32_t val) {
   qemu_log("TRACE \tSTORE REG %s Val: 0x%x\n", hex_regnames[reg], val);
   char reg_name[16] = { 0 };
   snprintf(reg_name, sizeof(reg_name) - 1, "%s_tmp", hex_regnames[reg]);
-  OperandInfo *oi = build_load_store_reg_op(reg_name, 1, &val, TARGET_LONG_BITS);
+  OperandInfo *oi = build_load_store_reg_op(reg_name, 1, &val, TARGET_LONG_BITS/4);
   qemu_trace_add_operand(oi, 0x2);
 }
 
@@ -192,7 +192,7 @@ void HELPER(trace_load_reg_pair)(uint32_t reg, uint64_t val) {
   qemu_log("TRACE \tLOAD REG %s:%s Val: 0x%lx\n", hex_regnames[reg+1], &hex_regnames[reg][1], val);
   char reg_name[16] = { 0 };
   snprintf(reg_name, sizeof(reg_name) - 1, "%s:%s", hex_regnames[reg+1], &hex_regnames[reg][1]);
-  OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS);
+  OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS/4);
   qemu_trace_add_operand(oi, 0x1);
 }
 
@@ -201,7 +201,7 @@ void HELPER(trace_load_reg_pair_new)(uint32_t reg, uint64_t val) {
   qemu_log("TRACE \tLOAD REG NEW %s:%s Val: 0x%lx\n", hex_regnames[reg+1], &hex_regnames[reg][1], val);
   char reg_name[16] = { 0 };
   snprintf(reg_name, sizeof(reg_name) - 1, "%s:%s_tmp", hex_regnames[reg+1], &hex_regnames[reg][1]);
-  OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS);
+  OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS/4);
   qemu_trace_add_operand(oi, 0x1);
 }
 
@@ -210,7 +210,7 @@ void HELPER(trace_store_reg_pair)(uint32_t reg, uint64_t val) {
   qemu_log("TRACE \tSTORE REG %s:%s Val: 0x%lx\n", hex_regnames[reg+1], &hex_regnames[reg][1], val);
   char reg_name[16] = { 0 };
   snprintf(reg_name, sizeof(reg_name) - 1, "%s:%s_tmp", hex_regnames[reg+1], &hex_regnames[reg][1]);
-  OperandInfo *oi = build_load_store_reg_op(reg_name, 1, &val, TARGET_LONG_BITS);
+  OperandInfo *oi = build_load_store_reg_op(reg_name, 1, &val, TARGET_LONG_BITS/4);
   qemu_trace_add_operand(oi, 0x2);
 }
 

--- a/target/hexagon/trace_helper.c
+++ b/target/hexagon/trace_helper.c
@@ -37,20 +37,16 @@ static const char * const hexagon_prednames[] = {
   "p0", "p1", "p2", "p3"
 };
 
-/*
- * Build frames
- *
- * Functions to fill the actual frame data.
- */
-
 /**
  * \brief Builds a new register load/store operand and returns it.
  *
  * \param name The register name.
- * \param ls If set to 0 the usage flag is set to "read". Otherwise the usage
- * flag is set to "written". \param data Data written to the register. \param
- * data_size Size of the data in bytes. \return OperandInfo* Pointer to the
- * operand for a BAP frame.
+ * \param ls If set to 0 the usage flag is set to "read".
+ *        Otherwise the usage flag is set to "written".
+ * \param data Data written to the register.
+ * \param data_size Size of the data in bytes.
+ *
+ * \return OperandInfo* Pointer to the operand for a BAP frame.
  */
 static OperandInfo *build_load_store_reg_op(const char *name, int ls,
                                             const void *data,

--- a/target/hexagon/trace_helper.c
+++ b/target/hexagon/trace_helper.c
@@ -163,53 +163,53 @@ void HELPER(trace_store_mem_64)(target_ulong addr, uint64_t val, MemOp op) {
 
 // GPRs
 void HELPER(trace_load_reg)(uint32_t reg, uint32_t val) {
-  assert(reg < sizeof(hexagon_regnames)/sizeof(hex_regnames[0]));
-  qemu_log("TRACE \tLOAD REG %s Val: 0x%x\n", hexagon_regnames[reg], val);
-  OperandInfo *oi = build_load_store_reg_op(hexagon_regnames[reg], 0, &val, TARGET_LONG_BITS);
+  assert(reg < sizeof(hex_regnames)/sizeof(hex_regnames[0]));
+  qemu_log("TRACE \tLOAD REG %s Val: 0x%x\n", hex_regnames[reg], val);
+  OperandInfo *oi = build_load_store_reg_op(hex_regnames[reg], 0, &val, TARGET_LONG_BITS);
   qemu_trace_add_operand(oi, 0x1);
 }
 
 void HELPER(trace_load_reg_new)(uint32_t reg, uint32_t val) {
-  assert(reg < sizeof(hexagon_regnames)/sizeof(hex_regnames[0]));
-  qemu_log("TRACE \tLOAD REG NEW %s Val: 0x%x\n", hexagon_regnames[reg], val);
+  assert(reg < sizeof(hex_regnames)/sizeof(hex_regnames[0]));
+  qemu_log("TRACE \tLOAD REG NEW %s Val: 0x%x\n", hex_regnames[reg], val);
   char reg_name[16] = { 0 };
-  snprintf(reg_name, sizeof(reg_name) - 1, "%s_tmp", hexagon_regnames[reg]);
+  snprintf(reg_name, sizeof(reg_name) - 1, "%s_tmp", hex_regnames[reg]);
   OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS);
   qemu_trace_add_operand(oi, 0x1);
 }
 
 void HELPER(trace_store_reg)(uint32_t reg, uint32_t val) {
-  assert(reg < sizeof(hexagon_regnames)/sizeof(hex_regnames[0]));
-  qemu_log("TRACE \tSTORE REG %s Val: 0x%x\n", hexagon_regnames[reg], val);
+  assert(reg < sizeof(hex_regnames)/sizeof(hex_regnames[0]));
+  qemu_log("TRACE \tSTORE REG %s Val: 0x%x\n", hex_regnames[reg], val);
   char reg_name[16] = { 0 };
-  snprintf(reg_name, sizeof(reg_name) - 1, "%s_tmp", hexagon_regnames[reg]);
+  snprintf(reg_name, sizeof(reg_name) - 1, "%s_tmp", hex_regnames[reg]);
   OperandInfo *oi = build_load_store_reg_op(reg_name, 1, &val, TARGET_LONG_BITS);
   qemu_trace_add_operand(oi, 0x2);
 }
 
 void HELPER(trace_load_reg_pair)(uint32_t reg, uint64_t val) {
-  assert(reg + 1 < sizeof(hexagon_regnames)/sizeof(hex_regnames[0]));
-  qemu_log("TRACE \tLOAD REG %s:%s Val: 0x%lx\n", hexagon_regnames[reg+1], &hexagon_regnames[reg][1], val);
+  assert(reg + 1 < sizeof(hex_regnames)/sizeof(hex_regnames[0]));
+  qemu_log("TRACE \tLOAD REG %s:%s Val: 0x%lx\n", hex_regnames[reg+1], &hex_regnames[reg][1], val);
   char reg_name[16] = { 0 };
-  snprintf(reg_name, sizeof(reg_name) - 1, "%s:%s", hexagon_regnames[reg+1], &hexagon_regnames[reg][1]);
+  snprintf(reg_name, sizeof(reg_name) - 1, "%s:%s", hex_regnames[reg+1], &hex_regnames[reg][1]);
   OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS);
   qemu_trace_add_operand(oi, 0x1);
 }
 
 void HELPER(trace_load_reg_pair_new)(uint32_t reg, uint64_t val) {
-  assert(reg + 1 < sizeof(hexagon_regnames)/sizeof(hex_regnames[0]));
-  qemu_log("TRACE \tLOAD REG NEW %s:%s Val: 0x%lx\n", hexagon_regnames[reg+1], &hexagon_regnames[reg][1], val);
+  assert(reg + 1 < sizeof(hex_regnames)/sizeof(hex_regnames[0]));
+  qemu_log("TRACE \tLOAD REG NEW %s:%s Val: 0x%lx\n", hex_regnames[reg+1], &hex_regnames[reg][1], val);
   char reg_name[16] = { 0 };
-  snprintf(reg_name, sizeof(reg_name) - 1, "%s:%s_tmp", hexagon_regnames[reg+1], &hexagon_regnames[reg][1]);
+  snprintf(reg_name, sizeof(reg_name) - 1, "%s:%s_tmp", hex_regnames[reg+1], &hex_regnames[reg][1]);
   OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS);
   qemu_trace_add_operand(oi, 0x1);
 }
 
 void HELPER(trace_store_reg_pair)(uint32_t reg, uint64_t val) {
-  assert(reg + 1 < sizeof(hexagon_regnames)/sizeof(hex_regnames[0]));
-  qemu_log("TRACE \tSTORE REG %s:%s Val: 0x%lx\n", hexagon_regnames[reg+1], &hexagon_regnames[reg][1], val);
+  assert(reg + 1 < sizeof(hex_regnames)/sizeof(hex_regnames[0]));
+  qemu_log("TRACE \tSTORE REG %s:%s Val: 0x%lx\n", hex_regnames[reg+1], &hex_regnames[reg][1], val);
   char reg_name[16] = { 0 };
-  snprintf(reg_name, sizeof(reg_name) - 1, "%s:%s_tmp", hexagon_regnames[reg+1], &hexagon_regnames[reg][1]);
+  snprintf(reg_name, sizeof(reg_name) - 1, "%s:%s_tmp", hex_regnames[reg+1], &hex_regnames[reg][1]);
   OperandInfo *oi = build_load_store_reg_op(reg_name, 1, &val, TARGET_LONG_BITS);
   qemu_trace_add_operand(oi, 0x2);
 }

--- a/target/hexagon/trace_helper.c
+++ b/target/hexagon/trace_helper.c
@@ -15,6 +15,23 @@ static void memcpy_rev(void *dest, const void *src, size_t size) {
 }
 #endif
 
+// Copies from genptr
+
+const char * const hex_regnames[TOTAL_PER_THREAD_REGS] = {
+   "r0", "r1",  "r2",  "r3",  "r4",   "r5",  "r6",  "r7",
+   "r8", "r9",  "r10", "r11", "r12",  "r13", "r14", "r15",
+  "r16", "r17", "r18", "r19", "r20",  "r21", "r22", "r23",
+  "r24", "r25", "r26", "r27", "r28",  "r29", "r30", "r31",
+  "sa0", "lc0", "sa1", "lc1", "p3_0", "c5",  "m0",  "m1",
+  "usr", "pc",  "ugp", "gp",  "cs0",  "cs1", "c14", "c15",
+  "c16", "c17", "c18", "c19", "pkt_cnt",  "insn_cnt", "hvx_cnt", "c23",
+  "c24", "c25", "c26", "c27", "c28",  "c29", "c30", "c31",
+};
+
+static const char * const hexagon_prednames[] = {
+  "p0", "p1", "p2", "p3"
+};
+
 /*
  * Build frames
  *
@@ -138,37 +155,37 @@ void HELPER(trace_store_mem_64)(target_ulong addr, uint64_t val, uint32_t width)
 // GPRs
 // name, return type, reg, val, load_new
 void HELPER(trace_load_reg)(uint32_t reg, uint32_t val) {
-  qemu_log("TRACE \tLOAD REG %d Val: 0x%x\n", reg, val);
+  qemu_log("TRACE \tLOAD REG %s Val: 0x%x\n", hexagon_regnames[reg], val);
   // OperandInfo *oi = build_load_store_reg_op(reg, val, 0, load_new);
   // qemu_trace_add_operand(oi, 0x1);
 }
 
 void HELPER(trace_load_reg_new)(uint32_t reg, uint32_t val) {
-  qemu_log("TRACE \tLOAD REG NEW %d Val: 0x%x\n", reg, val);
+  qemu_log("TRACE \tLOAD REG NEW %s Val: 0x%x\n", hexagon_regnames[reg], val);
   // OperandInfo *oi = build_load_store_reg_op(reg, val, 0, load_new);
   // qemu_trace_add_operand(oi, 0x1);
 }
 
 void HELPER(trace_store_reg)(uint32_t reg, uint32_t val) {
-  qemu_log("TRACE \tSTORE REG %d Val: 0x%x\n", reg, val);
+  qemu_log("TRACE \tSTORE REG %s Val: 0x%x\n", hexagon_regnames[reg], val);
   // OperandInfo *oi = load_store_reg(reg, val, 1);
   // qemu_trace_add_operand(oi, 0x2);
 }
 
 void HELPER(trace_load_reg_pair)(uint32_t reg, uint64_t val) {
-  qemu_log("TRACE \tLOAD REG %d Val: 0x%lx\n", reg, val);
+  qemu_log("TRACE \tLOAD REG %s:%s Val: 0x%lx\n", hexagon_regnames[reg+1], &hexagon_regnames[reg][1], val);
   // OperandInfo *oi = build_load_store_reg_op(reg, val, 0, load_new);
   // qemu_trace_add_operand(oi, 0x1);
 }
 
 void HELPER(trace_load_reg_pair_new)(uint32_t reg, uint64_t val) {
-  qemu_log("TRACE \tLOAD REG NEW %d Val: 0x%lx\n", reg, val);
+  qemu_log("TRACE \tLOAD REG NEW %s:%s Val: 0x%lx\n", hexagon_regnames[reg+1], &hexagon_regnames[reg][1], val);
   // OperandInfo *oi = build_load_store_reg_op(reg, val, 0, load_new);
   // qemu_trace_add_operand(oi, 0x1);
 }
 
 void HELPER(trace_store_reg_pair)(uint32_t reg, uint64_t val) {
-  qemu_log("TRACE \tSTORE REG %d Val: 0x%lx\n", reg, val);
+  qemu_log("TRACE \tSTORE REG %s:%s Val: 0x%lx\n", hexagon_regnames[reg+1], &hexagon_regnames[reg][1], val);
   // OperandInfo *oi = load_store_reg(reg, val, 1);
   // qemu_trace_add_operand(oi, 0x2);
 }
@@ -190,15 +207,15 @@ void HELPER(trace_store_vreg)(uint32_t vreg, void *val) {
 // Predicates
 // name, return type, pred reg, val, load_new
 void HELPER(trace_load_pred)(uint32_t pred, target_ulong val) {
-  qemu_log("TRACE \tLOAD PRED %d Val: 0x%x\n", pred, val);
+  qemu_log("TRACE \tLOAD PRED %s Val: 0x%x\n", hexagon_prednames[pred], val);
 }
 
 void HELPER(trace_load_pred_new)(uint32_t pred, target_ulong val) {
-  qemu_log("TRACE \tLOAD PRED NEW: %d Val: 0x%x\n", pred, val);
+  qemu_log("TRACE \tLOAD PRED NEW: %s Val: 0x%x\n", hexagon_prednames[pred], val);
 }
 
 void HELPER(trace_store_pred)(uint32_t pred, target_ulong val) {
-  qemu_log("TRACE \tSTORE PRED: %d Val: 0x%x\n", pred, val);
+  qemu_log("TRACE \tSTORE PRED: %s Val: 0x%x\n", hexagon_prednames[pred], val);
 }
 
 void HELPER(trace_load_vpred)(uint32_t vpred, void *val) {

--- a/target/hexagon/trace_helper.c
+++ b/target/hexagon/trace_helper.c
@@ -148,7 +148,7 @@ void HELPER(trace_store_mem_64)(target_ulong addr, uint64_t val, MemOp op) {
 void HELPER(trace_load_reg)(uint32_t reg, uint32_t val) {
   assert(reg < sizeof(hex_regnames)/sizeof(hex_regnames[0]));
   qemu_log("TRACE \tLOAD REG %s Val: 0x%x\n", hex_regnames[reg], val);
-  OperandInfo *oi = build_load_store_reg_op(hex_regnames[reg], 0, &val, TARGET_LONG_BITS/4);
+  OperandInfo *oi = build_load_store_reg_op(hex_regnames[reg], 0, &val, TARGET_LONG_BITS/8);
   qemu_trace_add_operand(oi, 0x1);
 }
 
@@ -157,7 +157,7 @@ void HELPER(trace_load_reg_new)(uint32_t reg, uint32_t val) {
   qemu_log("TRACE \tLOAD REG NEW %s Val: 0x%x\n", hex_regnames[reg], val);
   char reg_name[16] = { 0 };
   snprintf(reg_name, sizeof(reg_name) - 1, "%s_tmp", hex_regnames[reg]);
-  OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS/4);
+  OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS/8);
   qemu_trace_add_operand(oi, 0x1);
 }
 
@@ -166,7 +166,7 @@ void HELPER(trace_store_reg)(uint32_t reg, uint32_t val) {
   qemu_log("TRACE \tSTORE REG %s Val: 0x%x\n", hex_regnames[reg], val);
   char reg_name[16] = { 0 };
   snprintf(reg_name, sizeof(reg_name) - 1, "%s_tmp", hex_regnames[reg]);
-  OperandInfo *oi = build_load_store_reg_op(reg_name, 1, &val, TARGET_LONG_BITS/4);
+  OperandInfo *oi = build_load_store_reg_op(reg_name, 1, &val, TARGET_LONG_BITS/8);
   qemu_trace_add_operand(oi, 0x2);
 }
 
@@ -175,7 +175,7 @@ void HELPER(trace_load_reg_pair)(uint32_t reg, uint64_t val) {
   qemu_log("TRACE \tLOAD REG %s:%s Val: 0x%lx\n", hex_regnames[reg+1], &hex_regnames[reg][1], val);
   char reg_name[16] = { 0 };
   snprintf(reg_name, sizeof(reg_name) - 1, "%s:%s", hex_regnames[reg+1], &hex_regnames[reg][1]);
-  OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS/4);
+  OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS/8);
   qemu_trace_add_operand(oi, 0x1);
 }
 
@@ -184,7 +184,7 @@ void HELPER(trace_load_reg_pair_new)(uint32_t reg, uint64_t val) {
   qemu_log("TRACE \tLOAD REG NEW %s:%s Val: 0x%lx\n", hex_regnames[reg+1], &hex_regnames[reg][1], val);
   char reg_name[16] = { 0 };
   snprintf(reg_name, sizeof(reg_name) - 1, "%s:%s_tmp", hex_regnames[reg+1], &hex_regnames[reg][1]);
-  OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS/4);
+  OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS/8);
   qemu_trace_add_operand(oi, 0x1);
 }
 
@@ -193,7 +193,7 @@ void HELPER(trace_store_reg_pair)(uint32_t reg, uint64_t val) {
   qemu_log("TRACE \tSTORE REG %s:%s Val: 0x%lx\n", hex_regnames[reg+1], &hex_regnames[reg][1], val);
   char reg_name[16] = { 0 };
   snprintf(reg_name, sizeof(reg_name) - 1, "%s:%s_tmp", hex_regnames[reg+1], &hex_regnames[reg][1]);
-  OperandInfo *oi = build_load_store_reg_op(reg_name, 1, &val, TARGET_LONG_BITS/4);
+  OperandInfo *oi = build_load_store_reg_op(reg_name, 1, &val, TARGET_LONG_BITS/8);
   qemu_trace_add_operand(oi, 0x2);
 }
 

--- a/target/hexagon/trace_helper.c
+++ b/target/hexagon/trace_helper.c
@@ -231,15 +231,28 @@ void HELPER(trace_store_vreg)(uint32_t vreg, void *val) {
 // Predicates
 // name, return type, pred reg, val, load_new
 void HELPER(trace_load_pred)(uint32_t pred, target_ulong val) {
+  assert(pred < sizeof(hexagon_prednames)/sizeof(hexagon_prednames[0]));
   qemu_log("TRACE \tLOAD PRED %s Val: 0x%x\n", hexagon_prednames[pred], val);
+  OperandInfo *oi = build_load_store_reg_op(hexagon_prednames[pred], 0, &val, 1);
+  qemu_trace_add_operand(oi, 0x1);
 }
 
 void HELPER(trace_load_pred_new)(uint32_t pred, target_ulong val) {
+  assert(pred < sizeof(hexagon_prednames)/sizeof(hexagon_prednames[0]));
   qemu_log("TRACE \tLOAD PRED NEW: %s Val: 0x%x\n", hexagon_prednames[pred], val);
+  char pred_name[16] = { 0 };
+  snprintf(pred_name, sizeof(pred_name) - 1, "%s_tmp", hexagon_prednames[pred]);
+  OperandInfo *oi = build_load_store_reg_op(pred_name, 0, &val, 1);
+  qemu_trace_add_operand(oi, 0x1);
 }
 
 void HELPER(trace_store_pred)(uint32_t pred, target_ulong val) {
+  assert(pred < sizeof(hexagon_prednames)/sizeof(hexagon_prednames[0]));
   qemu_log("TRACE \tSTORE PRED: %s Val: 0x%x\n", hexagon_prednames[pred], val);
+  char pred_name[16] = { 0 };
+  snprintf(pred_name, sizeof(pred_name) - 1, "%s_tmp", hexagon_prednames[pred]);
+  OperandInfo *oi = build_load_store_reg_op(pred_name, 1, &val, 1);
+  qemu_trace_add_operand(oi, 0x2);
 }
 
 void HELPER(trace_load_vpred)(uint32_t vpred, void *val) {

--- a/target/hexagon/trace_helper.c
+++ b/target/hexagon/trace_helper.c
@@ -1,0 +1,206 @@
+#include "cpu.h"
+#include "exec/helper-proto.h"
+#include "exec/memop.h"
+#include "qemu/log.h"
+#include "tracewrap.h"
+
+#include "internal.h"
+
+#include "trace_helper.h"
+
+static const char * const hexagon_prednames[] = {
+  "p0", "p1", "p2", "p3"
+};
+
+/*
+ * QEMUs helper.
+ */
+
+void HELPER(trace_newframe)(uint64_t pc) { qemu_trace_newframe(pc, 0); }
+
+void HELPER(trace_endframe)(CPUHexagonState *state, uint64_t pc, uint32_t pkt_size) {
+  qemu_trace_endframe(state, pc, pkt_size);
+}
+
+void HELPER(trace_load_mem)(uint32_t addr, uint32_t val, uint32_t size) {
+  qemu_log("LOAD at 0x%lx size: %d data: 0x%lx\n", (unsigned long)addr,
+           size, (unsigned long)val);
+  OperandInfo *oi = load_store_mem(addr, 0, &val, size);
+  qemu_trace_add_operand(oi, 0x1);
+}
+
+void HELPER(trace_store_mem)(uint32_t addr, uint32_t val, uint32_t size) {
+  qemu_log("STORE at 0x%lx size: %d data: 0x%lx\n", (unsigned long)addr,
+           size, (unsigned long)val);
+  OperandInfo *oi = load_store_mem(addr, 1, &val, size);
+  qemu_trace_add_operand(oi, 0x2);
+}
+
+void HELPER(trace_load_mem_i64)(uint32_t addr, uint64_t val, uint32_t size) {
+  qemu_log("LOAD at 0x%lx size: %d data: 0x%llx\n", (unsigned long)addr,
+           size, (unsigned long long)val);
+  OperandInfo *oi = load_store_mem(addr, 0, &val, size);
+  qemu_trace_add_operand(oi, 0x1);
+}
+
+void HELPER(trace_store_mem_i64)(uint32_t addr, uint64_t val, uint32_t size) {
+  qemu_log("STORE at 0x%lx size: %d data: 0x%llx\n", (unsigned long)addr,
+           size, (unsigned long long)val);
+  OperandInfo *oi = load_store_mem(addr, 1, &val, size);
+  qemu_trace_add_operand(oi, 0x2);
+}
+
+void HELPER(trace_load_gpr)(uint32_t reg, uint32_t val) {
+  OperandInfo *oi = load_store_reg(reg, val, 0);
+  qemu_trace_add_operand(oi, 0x1);
+}
+
+void HELPER(trace_store_gpr)(uint32_t reg, uint32_t val) {
+  OperandInfo *oi = load_store_reg(reg, val, 1);
+  qemu_trace_add_operand(oi, 0x2);
+}
+
+// void HELPER(trace_store_crf)(uint32_t crf, uint32_t val)
+// {
+//     OperandInfo *oi = load_store_crf(crf, val, 1);
+//     qemu_trace_add_operand(oi, 0x2);
+// }
+
+// void HELPER(trace_load_crf)(uint32_t crf, uint32_t val)
+// {
+//     OperandInfo *oi = load_store_crf(crf, val, 0);
+//     qemu_trace_add_operand(oi, 0x1);
+// }
+
+// void HELPER(trace_load_spr_reg)(CPUPPCState *env, uint32_t reg, uint32_t
+// field, uint32_t val)
+// {
+//     const char *name = get_spr_name(reg, field, env);
+//     uint32_t size = sizeof(env->spr_cb[reg].default_value);
+//     OperandInfo *oi = load_store_spr_reg(name, val, size, 0);
+//     qemu_trace_add_operand(oi, 0x1);
+// }
+
+// void HELPER(trace_store_spr_reg)(CPUPPCState *env, uint32_t reg, uint32_t
+// field, uint32_t val)
+// {
+//     const char *name = get_spr_name(reg, field, env);
+//     uint32_t size = sizeof(env->spr_cb[reg].default_value);
+//     OperandInfo *oi = load_store_spr_reg(name, val, size, 1);
+//     qemu_trace_add_operand(oi, 0x2);
+// }
+
+#ifdef BSWAP_NEEDED
+static void memcpy_rev(void *dest, const void *src, size_t size) {
+  if (size < 1) {
+    return;
+  }
+  const char *s = src;
+  char *d = dest;
+  for (size_t i = 0, j = size - 1; i < size; --j, ++i) {
+    d[i] = s[j];
+  }
+}
+#endif
+
+/*
+ * Build frames
+ *
+ * Functions to fill the actual frame data.
+ */
+
+/**
+ * \brief Builds a new register load/store operand and returns it.
+ *
+ * \param name The register name.
+ * \param ls If set to 0 the usage flag is set to "read". Otherwise the usage
+ * flag is set to "written". \param data Data written to the register. \param
+ * data_size Size of the data in bytes. \return OperandInfo* Pointer to the
+ * operand for a BAP frame.
+ */
+static OperandInfo *build_load_store_reg_op(const char *name, int ls,
+                                            const void *data,
+                                            size_t data_size) {
+  RegOperand *ro = g_new(RegOperand, 1);
+  reg_operand__init(ro);
+  ro->name = strdup(name);
+
+  OperandInfoSpecific *ois = g_new(OperandInfoSpecific, 1);
+  operand_info_specific__init(ois);
+  ois->reg_operand = ro;
+
+  OperandUsage *ou = g_new(OperandUsage, 1);
+  operand_usage__init(ou);
+  if (ls == 0) {
+    ou->read = 1;
+  } else {
+    ou->written = 1;
+  }
+  OperandInfo *oi = g_new(OperandInfo, 1);
+  operand_info__init(oi);
+  oi->bit_length = 0;
+  oi->operand_info_specific = ois;
+  oi->operand_usage = ou;
+  oi->value.len = data_size;
+  oi->value.data = g_malloc(oi->value.len);
+  memcpy(oi->value.data, data, data_size);
+
+  return oi;
+}
+
+OperandInfo *load_store_mem(uint64_t addr, int ls, const void *data,
+                            size_t data_size) {
+  MemOperand *mo = g_new(MemOperand, 1);
+  mem_operand__init(mo);
+
+  mo->address = addr;
+
+  OperandInfoSpecific *ois = g_new(OperandInfoSpecific, 1);
+  operand_info_specific__init(ois);
+  ois->mem_operand = mo;
+
+  OperandUsage *ou = g_new(OperandUsage, 1);
+  operand_usage__init(ou);
+  if (ls == 0) {
+    ou->read = 1;
+  } else {
+    ou->written = 1;
+  }
+  OperandInfo *oi = g_new(OperandInfo, 1);
+  operand_info__init(oi);
+  oi->bit_length = data_size * 8;
+  oi->operand_info_specific = ois;
+  oi->operand_usage = ou;
+  oi->value.len = data_size;
+  oi->value.data = g_malloc(oi->value.len);
+#ifdef BSWAP_NEEDED
+  memcpy_rev(oi->value.data, data, data_size);
+#else
+  memcpy(oi->value.data, data, data_size);
+#endif
+  return oi;
+}
+
+OperandInfo *load_store_reg(uint32_t reg, uint32_t val, int ls) {
+  const char *name = hexagon_regnames[reg];
+  return build_load_store_reg_op(name, ls, &val, sizeof(val));
+}
+
+OperandInfo *load_store_reg64(uint32_t reg, uint64_t val, int ls) {
+  const char *name = hexagon_regnames[reg];
+  return build_load_store_reg_op(name, ls, &val, sizeof(val));
+}
+
+// OperandInfo *load_store_spr_reg(const char *name, uint64_t val, uint32_t size,
+//                                 int ls) {
+//   return build_load_store_reg_op(name, ls, &val, size);
+// }
+
+// void trace_dcbz(CPUPPCState *state, uint64_t addr) {
+//   qemu_log("Clear cache at 0x%lx size: %d data: 0x%llx\n", (unsigned long)addr,
+//            memop_size(state->dcache_line_size), (unsigned long long)0);
+//   char *val = calloc(state->dcache_line_size, 1);
+//   OperandInfo *oi = load_store_mem(addr, 1, val, state->dcache_line_size);
+//   qemu_trace_add_operand(oi, 0x2);
+//   free(val);
+// }

--- a/target/hexagon/trace_helper.c
+++ b/target/hexagon/trace_helper.c
@@ -129,35 +129,53 @@ void HELPER(trace_store_mem)(target_ulong addr, uint64_t val, uint32_t width) {
 // GPRs
 // name, return type, reg, val, is_tmp
 void HELPER(trace_load_reg)(uint32_t reg, target_ulong val, uint32_t is_tmp) {
+  qemu_log("LOAD REG %d Val: 0x%x TMP: %d\n", reg, val, is_tmp);
   // OperandInfo *oi = load_store_reg(reg, val, 0);
   // qemu_trace_add_operand(oi, 0x1);
 }
 
 void HELPER(trace_store_reg)(uint32_t reg, target_ulong val, uint32_t is_tmp) {
+  qemu_log("STORE REG %d Val: 0x%x TMP: %d\n", reg, val, is_tmp);
   // OperandInfo *oi = load_store_reg(reg, val, 1);
   // qemu_trace_add_operand(oi, 0x2);
 }
 
 // VRegs
 // name, return type, vreg, val, is_tmp
-void HELPER(trace_load_vreg)(uint32_t vreg, void *val, uint32_t is_tmp) {}
-void HELPER(trace_store_vreg)(uint32_t vreg, void *val, uint32_t is_tmp) {}
+void HELPER(trace_load_vreg)(uint32_t vreg, void *val, uint32_t is_tmp) {
+  qemu_log("LOAD VREG %d Val: %p TMP: %d\n", vreg, val, is_tmp);
+}
+
+void HELPER(trace_store_vreg)(uint32_t vreg, void *val, uint32_t is_tmp) {
+  qemu_log("STORE VREG %d Val: %p TMP: %d\n", vreg, val, is_tmp);
+}
 
 // Predicates
 // name, return type, pred reg, val, is_tmp
 void HELPER(trace_load_pred)(uint32_t pred, target_ulong val, uint32_t is_tmp) {
+  qemu_log("LOAD PRED %d Val: 0x%x TMP: %d\n", pred, val, is_tmp);
 }
-void HELPER(trace_store_pred)(uint32_t pred, target_ulong val,
-                              uint32_t is_tmp) {}
 
-void HELPER(trace_load_vpred)(uint32_t vpred, void *val, uint32_t is_tmp) {}
-void HELPER(trace_store_vpred)(uint32_t vpred, void *val, uint32_t is_tmp) {}
+void HELPER(trace_store_pred)(uint32_t pred, target_ulong val,
+                              uint32_t is_tmp) {
+  qemu_log("STORE PRED %d Val: 0x%x TMP: %d\n", pred, val, is_tmp);
+}
+
+void HELPER(trace_load_vpred)(uint32_t vpred, void *val, uint32_t is_tmp) {
+  qemu_log("LOAD VPRED %d Val: %p TMP: %d\n", vpred, val, is_tmp);
+}
+
+void HELPER(trace_store_vpred)(uint32_t vpred, void *val, uint32_t is_tmp) {
+  qemu_log("STORE VPRED %d Val: %p TMP: %d\n", vpred, val, is_tmp);
+}
 
 // special registers (USR etc.)
 // name, return type, ctrl reg, reg field, value, is_tmp
 void HELPER(trace_store_ctrl)(uint32_t creg, uint32_t field, target_ulong val,
-                              uint32_t is_tmp) {}
+                              uint32_t is_tmp) {
+  qemu_log("STORE CTRL REG: %d FIELD: %d Val: 0x%x TMP: %d\n", creg, field, val, is_tmp);
+}
 void HELPER(trace_load_ctrl)(uint32_t creg, uint32_t field, target_ulong val,
-                             uint32_t is_tmp) {}
-
-void HELPER(trace_store_gpr)(uint32_t reg, uint32_t val) {}
+                             uint32_t is_tmp) {
+  qemu_log("LOAD CTRL REG: %d FIELD: %d Val: 0x%x TMP: %d\n", creg, field, val, is_tmp);
+}

--- a/target/hexagon/trace_helper.c
+++ b/target/hexagon/trace_helper.c
@@ -20,12 +20,17 @@ static void memcpy_rev(void *dest, const void *src, size_t size) {
 const char * const hex_regnames[TOTAL_PER_THREAD_REGS] = {
    "r0", "r1",  "r2",  "r3",  "r4",   "r5",  "r6",  "r7",
    "r8", "r9",  "r10", "r11", "r12",  "r13", "r14", "r15",
-  "r16", "r17", "r18", "r19", "r20",  "r21", "r22", "r23",
-  "r24", "r25", "r26", "r27", "r28",  "r29", "r30", "r31",
-  "sa0", "lc0", "sa1", "lc1", "p3_0", "c5",  "m0",  "m1",
-  "usr", "pc",  "ugp", "gp",  "cs0",  "cs1", "c14", "c15",
-  "c16", "c17", "c18", "c19", "pkt_cnt",  "insn_cnt", "hvx_cnt", "c23",
-  "c24", "c25", "c26", "c27", "c28",  "c29", "c30", "c31",
+   "r16", "r17", "r18", "r19", "r20",  "r21", "r22", "r23",
+   "r24", "r25", "r26", "r27", "r28",  "r29", "r30", "r31",
+   "c0" /* sa0 */, "c1" /* lc0 */, "c2" /* sa1 */, "c3" /* lc1 */,
+   "c4" /* p3_0 */,  "c5" /* c5 */, "c6" /* m0 */, "c7" /* m1 */,
+   "c8" /* usr */, "c9" /* pc */, "c10" /* ugp */, "c11" /* gp */,
+   "c12" /* cs0 */, "c13" /* cs1 */, "c14" /* c14 */, "c15" /* c15 */,
+   "c16" /* c16 */, "c17" /* c17 */, "c18" /* c18 */, "c19" /* c19 */,
+   "c20" /* pkt_cnt */, "c21" /* insn_cnt */, "c22" /* hvx_cnt */,
+   "c23" /* c23 */, "c24" /* c24 */, "c25" /* c25 */, "c26" /* c26 */,
+   "c27" /* c27 */, "c28" /* c28 */, "c29" /* c29 */, "c30" /* c30 */,
+   "c31" /* c31 */,
 };
 
 static const char * const hexagon_prednames[] = {
@@ -183,21 +188,30 @@ void HELPER(trace_store_reg)(uint32_t reg, uint32_t val) {
 }
 
 void HELPER(trace_load_reg_pair)(uint32_t reg, uint64_t val) {
+  assert(reg + 1 < sizeof(hexagon_regnames)/sizeof(hex_regnames[0]));
   qemu_log("TRACE \tLOAD REG %s:%s Val: 0x%lx\n", hexagon_regnames[reg+1], &hexagon_regnames[reg][1], val);
-  // OperandInfo *oi = build_load_store_reg_op(reg, val, 0, load_new);
-  // qemu_trace_add_operand(oi, 0x1);
+  char reg_name[16] = { 0 };
+  snprintf(reg_name, sizeof(reg_name) - 1, "%s:%s", hexagon_regnames[reg+1], &hexagon_regnames[reg][1]);
+  OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS);
+  qemu_trace_add_operand(oi, 0x1);
 }
 
 void HELPER(trace_load_reg_pair_new)(uint32_t reg, uint64_t val) {
+  assert(reg + 1 < sizeof(hexagon_regnames)/sizeof(hex_regnames[0]));
   qemu_log("TRACE \tLOAD REG NEW %s:%s Val: 0x%lx\n", hexagon_regnames[reg+1], &hexagon_regnames[reg][1], val);
-  // OperandInfo *oi = build_load_store_reg_op(reg, val, 0, load_new);
-  // qemu_trace_add_operand(oi, 0x1);
+  char reg_name[16] = { 0 };
+  snprintf(reg_name, sizeof(reg_name) - 1, "%s:%s_tmp", hexagon_regnames[reg+1], &hexagon_regnames[reg][1]);
+  OperandInfo *oi = build_load_store_reg_op(reg_name, 0, &val, TARGET_LONG_BITS);
+  qemu_trace_add_operand(oi, 0x1);
 }
 
 void HELPER(trace_store_reg_pair)(uint32_t reg, uint64_t val) {
+  assert(reg + 1 < sizeof(hexagon_regnames)/sizeof(hex_regnames[0]));
   qemu_log("TRACE \tSTORE REG %s:%s Val: 0x%lx\n", hexagon_regnames[reg+1], &hexagon_regnames[reg][1], val);
-  // OperandInfo *oi = load_store_reg(reg, val, 1);
-  // qemu_trace_add_operand(oi, 0x2);
+  char reg_name[16] = { 0 };
+  snprintf(reg_name, sizeof(reg_name) - 1, "%s:%s_tmp", hexagon_regnames[reg+1], &hexagon_regnames[reg][1]);
+  OperandInfo *oi = build_load_store_reg_op(reg_name, 1, &val, TARGET_LONG_BITS);
+  qemu_trace_add_operand(oi, 0x2);
 }
 
 // VRegs

--- a/target/hexagon/trace_helper.c
+++ b/target/hexagon/trace_helper.c
@@ -110,80 +110,68 @@ void HELPER(trace_endframe)(CPUHexagonState *state, target_ulong addr,
 // Memory
 // name, return type, address, val, width
 void HELPER(trace_load_mem)(target_ulong addr, uint64_t val, uint32_t width) {
-  qemu_log("LOAD at 0x%x width: %d data: 0x%lx\n", addr, width, val);
+  qemu_log("\tLOAD at 0x%x width: %d data: 0x%lx\n", addr, width, val);
   OperandInfo *oi = build_load_store_mem(addr, 0, &val, width);
   qemu_trace_add_operand(oi, 0x1);
 }
 
 void HELPER(trace_store_mem)(target_ulong addr, uint64_t val, uint32_t width) {
-  qemu_log("STORE at 0x%lx width: %d data: 0x%lx\n", (unsigned long)addr, width,
+  qemu_log("\tSTORE at 0x%lx width: %d data: 0x%lx\n", (unsigned long)addr, width,
            (unsigned long)val);
   OperandInfo *oi = build_load_store_mem(addr, 1, &val, width);
   qemu_trace_add_operand(oi, 0x2);
 }
 
 // GPRs
-// name, return type, reg, val, is_tmp
-void HELPER(trace_load_reg)(uint32_t reg, uint32_t val, uint32_t is_tmp) {
-  qemu_log("LOAD REG %d Val: 0x%x TMP: %d\n", reg, val, is_tmp);
-  // OperandInfo *oi = build_load_store_reg_op(reg, val, 0, is_tmp);
+// name, return type, reg, val, load_new
+void HELPER(trace_load_reg)(uint32_t reg, uint32_t val, uint32_t load_new) {
+  qemu_log("\tLOAD REG %d Val: 0x%x TMP: %d\n", reg, val, load_new);
+  // OperandInfo *oi = build_load_store_reg_op(reg, val, 0, load_new);
   // qemu_trace_add_operand(oi, 0x1);
 }
 
-void HELPER(trace_store_reg)(uint32_t reg, uint32_t val, uint32_t is_tmp) {
-  qemu_log("STORE REG %d Val: 0x%x TMP: %d\n", reg, val, is_tmp);
+void HELPER(trace_store_reg)(uint32_t reg, uint32_t val) {
+  qemu_log("\tSTORE REG %d Val: 0x%x\n", reg, val);
   // OperandInfo *oi = load_store_reg(reg, val, 1);
   // qemu_trace_add_operand(oi, 0x2);
 }
 
-void HELPER(trace_load_reg_pair)(uint32_t reg, uint64_t val, uint32_t is_tmp) {
-  qemu_log("LOAD REG %d Val: 0x%lx TMP: %d\n", reg, val, is_tmp);
-  // OperandInfo *oi = build_load_store_reg_op(reg, val, 0, is_tmp);
+void HELPER(trace_load_reg_pair)(uint32_t reg, uint64_t val, uint32_t load_new) {
+  qemu_log("\tLOAD REG %d Val: 0x%lx TMP: %d\n", reg, val, load_new);
+  // OperandInfo *oi = build_load_store_reg_op(reg, val, 0, load_new);
   // qemu_trace_add_operand(oi, 0x1);
 }
 
-void HELPER(trace_store_reg_pair)(uint32_t reg, uint64_t val, uint32_t is_tmp) {
-  qemu_log("STORE REG %d Val: 0x%lx TMP: %d\n", reg, val, is_tmp);
+void HELPER(trace_store_reg_pair)(uint32_t reg, uint64_t val) {
+  qemu_log("\tSTORE REG %d Val: 0x%lx\n", reg, val);
   // OperandInfo *oi = load_store_reg(reg, val, 1);
   // qemu_trace_add_operand(oi, 0x2);
 }
 
 // VRegs
-// name, return type, vreg, val, is_tmp
-void HELPER(trace_load_vreg)(uint32_t vreg, void *val, uint32_t is_tmp) {
-  qemu_log("LOAD VREG %d Val: %p TMP: %d\n", vreg, val, is_tmp);
+// name, return type, vreg, val, load_new
+void HELPER(trace_load_vreg)(uint32_t vreg, void *val, uint32_t load_new) {
+  qemu_log("\tLOAD VREG %d Val: %p TMP: %d\n", vreg, val, load_new);
 }
 
-void HELPER(trace_store_vreg)(uint32_t vreg, void *val, uint32_t is_tmp) {
-  qemu_log("STORE VREG %d Val: %p TMP: %d\n", vreg, val, is_tmp);
+void HELPER(trace_store_vreg)(uint32_t vreg, void *val) {
+  qemu_log("\tSTORE VREG %d Val: %p\n", vreg, val);
 }
 
 // Predicates
-// name, return type, pred reg, val, is_tmp
-void HELPER(trace_load_pred)(uint32_t pred, target_ulong val, uint32_t is_tmp) {
-  qemu_log("LOAD PRED %d Val: 0x%x TMP: %d\n", pred, val, is_tmp);
+// name, return type, pred reg, val, load_new
+void HELPER(trace_load_pred)(uint32_t pred, target_ulong val, uint32_t load_new) {
+  qemu_log("\tLOAD PRED %d Val: 0x%x TMP: %d\n", pred, val, load_new);
 }
 
-void HELPER(trace_store_pred)(uint32_t pred, target_ulong val,
-                              uint32_t is_tmp) {
-  qemu_log("STORE PRED %d Val: 0x%x TMP: %d\n", pred, val, is_tmp);
+void HELPER(trace_store_pred)(uint32_t pred, target_ulong val) {
+  qemu_log("\tSTORE PRED %d Val: 0x%x\n", pred, val);
 }
 
-void HELPER(trace_load_vpred)(uint32_t vpred, void *val, uint32_t is_tmp) {
-  qemu_log("LOAD VPRED %d Val: %p TMP: %d\n", vpred, val, is_tmp);
+void HELPER(trace_load_vpred)(uint32_t vpred, void *val, uint32_t load_new) {
+  qemu_log("\tLOAD VPRED %d Val: %p TMP: %d\n", vpred, val, load_new);
 }
 
-void HELPER(trace_store_vpred)(uint32_t vpred, void *val, uint32_t is_tmp) {
-  qemu_log("STORE VPRED %d Val: %p TMP: %d\n", vpred, val, is_tmp);
-}
-
-// special registers (USR etc.)
-// name, return type, ctrl reg, reg field, value, is_tmp
-void HELPER(trace_store_ctrl)(uint32_t creg, uint32_t field, target_ulong val,
-                              uint32_t is_tmp) {
-  qemu_log("STORE CTRL REG: %d FIELD: %d Val: 0x%x TMP: %d\n", creg, field, val, is_tmp);
-}
-void HELPER(trace_load_ctrl)(uint32_t creg, uint32_t field, target_ulong val,
-                             uint32_t is_tmp) {
-  qemu_log("LOAD CTRL REG: %d FIELD: %d Val: 0x%x TMP: %d\n", creg, field, val, is_tmp);
+void HELPER(trace_store_vpred)(uint32_t vpred, void *val) {
+  qemu_log("\tSTORE VPRED %d Val: %p\n", vpred, val);
 }

--- a/target/hexagon/trace_helper.h
+++ b/target/hexagon/trace_helper.h
@@ -1,0 +1,9 @@
+#ifndef TRACE_HELPER
+#define TRACE_HELPER
+
+#include "tracewrap.h"
+
+OperandInfo *load_store_crf(uint32_t reg, uint64_t val, int ls);
+OperandInfo *load_store_spr_reg(const char *name, uint64_t val, uint32_t size, int ls);
+
+#endif /* TRACE_HELPER */

--- a/target/hexagon/trace_helper.h
+++ b/target/hexagon/trace_helper.h
@@ -2,8 +2,21 @@
 #define TRACE_HELPER
 
 #include "tracewrap.h"
-
-OperandInfo *load_store_crf(uint32_t reg, uint64_t val, int ls);
-OperandInfo *load_store_spr_reg(const char *name, uint64_t val, uint32_t size, int ls);
+#include "qemu/osdep.h"
+#include "qemu/log.h"
+#include "exec/exec-all.h"
+#include "exec/cpu_ldst.h"
+#include "exec/helper-proto.h"
+#include "fpu/softfloat.h"
+#include "cpu.h"
+#include "internal.h"
+#include "macros.h"
+#include "arch.h"
+#include "hex_arch_types.h"
+#include "fma_emu.h"
+#include "mmvec/mmvec.h"
+#include "mmvec/macros.h"
+#include "op_helper.h"
+#include "translate.h"
 
 #endif /* TRACE_HELPER */

--- a/target/hexagon/translate.c
+++ b/target/hexagon/translate.c
@@ -687,8 +687,11 @@ static void gen_reg_writes(DisasContext *ctx)
         int reg_num = ctx->reg_log[i];
 
         tcg_gen_mov_tl(hex_gpr[reg_num], get_result_gpr(ctx, reg_num));
-        if (reg_num != HEX_REG_PC) {
+        if (reg_num != HEX_REG_PC && reg_num != HEX_REG_LC0) {
             // PC writes are not tracked.
+            // LC0 is never tracked, because at this point it doesn't necessarily
+            // hold the correct value.
+            // Due to direct blocck chaining, it might hold the not decremented value.
             gen_helper_trace_store_reg(tcg_constant_i32(reg_num), hex_gpr[reg_num]);
         }
 

--- a/target/hexagon/translate.c
+++ b/target/hexagon/translate.c
@@ -697,7 +697,7 @@ static void gen_pred_writes(DisasContext *ctx)
     for (int i = 0; i < ctx->preg_log_idx; i++) {
         int pred_num = ctx->preg_log[i];
         tcg_gen_mov_tl(hex_pred[pred_num], ctx->new_pred_value[pred_num]);
-        gen_helper_trace_store_reg(tcg_constant_i32(pred_num), hex_pred[pred_num]);
+        gen_helper_trace_store_pred(tcg_constant_i32(pred_num), hex_pred[pred_num]);
     }
 }
 

--- a/target/hexagon/translate.c
+++ b/target/hexagon/translate.c
@@ -573,6 +573,7 @@ static void gen_start_packet(DisasContext *ctx)
             int pred_num = ctx->preg_log[i];
             ctx->new_pred_value[pred_num] = tcg_temp_new();
             tcg_gen_mov_tl(ctx->new_pred_value[pred_num], hex_pred[pred_num]);
+            gen_helper_trace_store_pred_new(tcg_constant_i32(pred_num), hex_pred[pred_num]);
         }
     }
 
@@ -761,24 +762,28 @@ void process_store(DisasContext *ctx, int slot_num)
             tcg_gen_qemu_st_tl(hex_store_val32[slot_num],
                                hex_store_addr[slot_num],
                                ctx->mem_idx, MO_UB);
+            gen_helper_trace_store_mem(hex_store_addr[slot_num], hex_store_val32[slot_num], tcg_constant_i32(MO_UB));
             break;
         case 2:
             gen_check_store_width(ctx, slot_num);
             tcg_gen_qemu_st_tl(hex_store_val32[slot_num],
                                hex_store_addr[slot_num],
                                ctx->mem_idx, MO_TEUW);
+            gen_helper_trace_store_mem(hex_store_addr[slot_num], hex_store_val32[slot_num], tcg_constant_i32(MO_TEUW));
             break;
         case 4:
             gen_check_store_width(ctx, slot_num);
             tcg_gen_qemu_st_tl(hex_store_val32[slot_num],
                                hex_store_addr[slot_num],
                                ctx->mem_idx, MO_TEUL);
+            gen_helper_trace_store_mem(hex_store_addr[slot_num], hex_store_val32[slot_num], tcg_constant_i32(MO_TEUL));
             break;
         case 8:
             gen_check_store_width(ctx, slot_num);
             tcg_gen_qemu_st_i64(hex_store_val64[slot_num],
                                 hex_store_addr[slot_num],
                                 ctx->mem_idx, MO_TEUQ);
+            gen_helper_trace_store_mem_64(hex_store_addr[slot_num], hex_store_val64[slot_num], tcg_constant_i32(MO_TEUQ));
             break;
         default:
             {

--- a/target/hexagon/translate.c
+++ b/target/hexagon/translate.c
@@ -141,11 +141,13 @@ static void gen_goto_tb(DisasContext *ctx, int idx, target_ulong dest, bool
         tcg_gen_goto_tb(idx);
         if (move_to_pc) {
             tcg_gen_movi_tl(hex_gpr[HEX_REG_PC], dest);
+            gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_PC), hex_gpr[HEX_REG_PC]);
         }
         tcg_gen_exit_tb(ctx->base.tb, idx);
     } else {
         if (move_to_pc) {
             tcg_gen_movi_tl(hex_gpr[HEX_REG_PC], dest);
+            gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_PC), hex_gpr[HEX_REG_PC]);
         }
         tcg_gen_lookup_and_goto_ptr();
     }
@@ -192,6 +194,7 @@ static void gen_exception_end_tb(DisasContext *ctx, int excp)
     gen_helper_trace_endframe(cpu_env, tcg_constant_tl(ctx->base.pc_next), tcg_constant_i32(0));
     gen_exec_counters(ctx);
     tcg_gen_movi_tl(hex_gpr[HEX_REG_PC], ctx->next_PC);
+    gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_PC), hex_gpr[HEX_REG_PC]);
     gen_exception_raw(excp);
     ctx->base.is_jmp = DISAS_NORETURN;
 
@@ -546,6 +549,7 @@ static void gen_start_packet(DisasContext *ctx)
         }
         if (need_next_PC(ctx)) {
             tcg_gen_movi_tl(hex_gpr[HEX_REG_PC], next_PC);
+            gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_PC), hex_gpr[HEX_REG_PC]);
         }
     }
     if (HEX_DEBUG) {
@@ -1139,6 +1143,7 @@ static void hexagon_tr_tb_stop(DisasContextBase *dcbase, CPUState *cpu)
     case DISAS_TOO_MANY:
         gen_exec_counters(ctx);
         tcg_gen_movi_tl(hex_gpr[HEX_REG_PC], ctx->base.pc_next);
+        gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_PC), hex_gpr[HEX_REG_PC]);
         tcg_gen_exit_tb(NULL, 0);
         break;
     case DISAS_NORETURN:

--- a/target/hexagon/translate.c
+++ b/target/hexagon/translate.c
@@ -155,7 +155,7 @@ static void gen_end_tb(DisasContext *ctx)
 {
     Packet *pkt = ctx->pkt;
 
-    gen_helper_trace_endframe(cpu_env, tcg_constant_tl(pkt->pc), tcg_constant_i32(pkt->num_insns));
+    gen_helper_trace_endframe(cpu_env, tcg_constant_tl(pkt->pc), tcg_constant_i32(pkt->encod_pkt_size_in_bytes/4));
     gen_exec_counters(ctx);
 
     if (ctx->branch_cond != TCG_COND_NEVER) {
@@ -1055,7 +1055,7 @@ static void decode_and_translate_packet(CPUHexagonState *env, DisasContext *ctx)
         }
         gen_commit_packet(ctx);
         ctx->base.pc_next += pkt.encod_pkt_size_in_bytes;
-        gen_helper_trace_endframe(cpu_env, tcg_constant_tl(pkt.pc), tcg_constant_i32(pkt.num_insns));
+        gen_helper_trace_endframe(cpu_env, tcg_constant_tl(pkt.pc), tcg_constant_i32(nwords));
     } else {
         gen_exception_end_tb(ctx, HEX_EXCP_INVALID_PACKET);
     }

--- a/target/hexagon/translate.c
+++ b/target/hexagon/translate.c
@@ -141,13 +141,11 @@ static void gen_goto_tb(DisasContext *ctx, int idx, target_ulong dest, bool
         tcg_gen_goto_tb(idx);
         if (move_to_pc) {
             tcg_gen_movi_tl(hex_gpr[HEX_REG_PC], dest);
-            gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_PC), hex_gpr[HEX_REG_PC]);
         }
         tcg_gen_exit_tb(ctx->base.tb, idx);
     } else {
         if (move_to_pc) {
             tcg_gen_movi_tl(hex_gpr[HEX_REG_PC], dest);
-            gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_PC), hex_gpr[HEX_REG_PC]);
         }
         tcg_gen_lookup_and_goto_ptr();
     }
@@ -194,7 +192,6 @@ static void gen_exception_end_tb(DisasContext *ctx, int excp)
     gen_helper_trace_endframe(cpu_env, tcg_constant_tl(ctx->base.pc_next), tcg_constant_i32(0));
     gen_exec_counters(ctx);
     tcg_gen_movi_tl(hex_gpr[HEX_REG_PC], ctx->next_PC);
-    gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_PC), hex_gpr[HEX_REG_PC]);
     gen_exception_raw(excp);
     ctx->base.is_jmp = DISAS_NORETURN;
 
@@ -549,7 +546,6 @@ static void gen_start_packet(DisasContext *ctx)
         }
         if (need_next_PC(ctx)) {
             tcg_gen_movi_tl(hex_gpr[HEX_REG_PC], next_PC);
-            gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_PC), hex_gpr[HEX_REG_PC]);
         }
     }
     if (HEX_DEBUG) {
@@ -1042,7 +1038,6 @@ static void decode_and_translate_packet(CPUHexagonState *env, DisasContext *ctx)
     int i;
 
     gen_helper_trace_newframe(tcg_constant_tl(ctx->base.pc_next));
-    gen_helper_trace_load_reg(tcg_constant_i32(HEX_REG_PC), tcg_constant_tl(ctx->base.pc_next));
     nwords = read_packet_words(env, ctx, words);
     if (!nwords) {
         gen_exception_end_tb(ctx, HEX_EXCP_INVALID_PACKET);
@@ -1060,7 +1055,6 @@ static void decode_and_translate_packet(CPUHexagonState *env, DisasContext *ctx)
         }
         gen_commit_packet(ctx);
         ctx->base.pc_next += pkt.encod_pkt_size_in_bytes;
-        gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_PC), tcg_constant_tl(ctx->base.pc_next));
         gen_helper_trace_endframe(cpu_env, tcg_constant_tl(pkt.pc), tcg_constant_i32(pkt.num_insns));
     } else {
         gen_exception_end_tb(ctx, HEX_EXCP_INVALID_PACKET);
@@ -1145,7 +1139,6 @@ static void hexagon_tr_tb_stop(DisasContextBase *dcbase, CPUState *cpu)
     case DISAS_TOO_MANY:
         gen_exec_counters(ctx);
         tcg_gen_movi_tl(hex_gpr[HEX_REG_PC], ctx->base.pc_next);
-        gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_PC), hex_gpr[HEX_REG_PC]);
         tcg_gen_exit_tb(NULL, 0);
         break;
     case DISAS_NORETURN:

--- a/target/hexagon/translate.c
+++ b/target/hexagon/translate.c
@@ -675,6 +675,7 @@ static void gen_reg_writes(DisasContext *ctx)
         int reg_num = ctx->reg_log[i];
 
         tcg_gen_mov_tl(hex_gpr[reg_num], get_result_gpr(ctx, reg_num));
+        gen_helper_trace_store_reg(tcg_constant_i32(reg_num), hex_gpr[reg_num]);
 
         /*
          * ctx->is_tight_loop is set when SA0 points to the beginning of the TB.
@@ -696,6 +697,7 @@ static void gen_pred_writes(DisasContext *ctx)
     for (int i = 0; i < ctx->preg_log_idx; i++) {
         int pred_num = ctx->preg_log[i];
         tcg_gen_mov_tl(hex_pred[pred_num], ctx->new_pred_value[pred_num]);
+        gen_helper_trace_store_reg(tcg_constant_i32(pred_num), hex_pred[pred_num]);
     }
 }
 

--- a/target/hexagon/translate.c
+++ b/target/hexagon/translate.c
@@ -522,6 +522,12 @@ static void gen_start_packet(DisasContext *ctx)
     }
 
     analyze_packet(ctx);
+    for (int i = 0; i < TOTAL_PER_THREAD_REGS; ++i) {
+        gen_helper_trace_load_reg(tcg_constant_i32(i), hex_gpr[i]);
+    }
+    for (int i = 0; i < NUM_PREGS; ++i) {
+        gen_helper_trace_load_pred(tcg_constant_i32(i), hex_pred[i]);
+    }
 
     /*
      * pregs_written is used both in the analyze phase as well as the code
@@ -573,8 +579,7 @@ static void gen_start_packet(DisasContext *ctx)
             int pred_num = ctx->preg_log[i];
             ctx->new_pred_value[pred_num] = tcg_temp_new();
             tcg_gen_mov_tl(ctx->new_pred_value[pred_num], hex_pred[pred_num]);
-            gen_helper_trace_store_pred_new(tcg_constant_i32(pred_num), hex_pred[pred_num]);
-        }
+       }
     }
 
     /* Preload the predicated HVX registers into future_VRegs and tmp_VRegs */

--- a/target/hexagon/translate.c
+++ b/target/hexagon/translate.c
@@ -154,11 +154,10 @@ static void gen_goto_tb(DisasContext *ctx, int idx, target_ulong dest, bool
 static void gen_end_tb(DisasContext *ctx)
 {
     Packet *pkt = ctx->pkt;
-
+    gen_helper_trace_endframe(cpu_env, tcg_constant_tl(pkt->pc), tcg_constant_i32(pkt->encod_pkt_size_in_bytes/4));
     gen_exec_counters(ctx);
 
     if (ctx->branch_cond != TCG_COND_NEVER) {
-        gen_helper_trace_endframe(cpu_env, tcg_constant_tl(pkt->pc), tcg_constant_i32(pkt->encod_pkt_size_in_bytes/4));
         if (ctx->branch_cond != TCG_COND_ALWAYS) {
             TCGLabel *skip = gen_new_label();
             tcg_gen_brcondi_tl(ctx->branch_cond, ctx->branch_taken, 0, skip);
@@ -177,13 +176,10 @@ static void gen_end_tb(DisasContext *ctx)
         TCGLabel *skip = gen_new_label();
         tcg_gen_brcondi_tl(TCG_COND_LEU, hex_gpr[HEX_REG_LC0], 1, skip);
         tcg_gen_subi_tl(hex_gpr[HEX_REG_LC0], hex_gpr[HEX_REG_LC0], 1);
-        gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_LC0), hex_gpr[HEX_REG_LC0]);
         gen_goto_tb(ctx, 0, ctx->base.tb->pc, true);
         gen_set_label(skip);
-        gen_helper_trace_endframe(cpu_env, tcg_constant_tl(pkt->pc), tcg_constant_i32(pkt->encod_pkt_size_in_bytes/4));
         gen_goto_tb(ctx, 1, ctx->next_PC, false);
     } else {
-        gen_helper_trace_endframe(cpu_env, tcg_constant_tl(pkt->pc), tcg_constant_i32(pkt->encod_pkt_size_in_bytes/4));
         tcg_gen_lookup_and_goto_ptr();
     }
 

--- a/target/hexagon/translate.c
+++ b/target/hexagon/translate.c
@@ -1042,6 +1042,7 @@ static void decode_and_translate_packet(CPUHexagonState *env, DisasContext *ctx)
     int i;
 
     gen_helper_trace_newframe(tcg_constant_tl(ctx->base.pc_next));
+    gen_helper_trace_load_reg(tcg_constant_i32(HEX_REG_PC), tcg_constant_tl(ctx->base.pc_next));
     nwords = read_packet_words(env, ctx, words);
     if (!nwords) {
         gen_exception_end_tb(ctx, HEX_EXCP_INVALID_PACKET);

--- a/target/hexagon/translate.c
+++ b/target/hexagon/translate.c
@@ -524,9 +524,11 @@ static void gen_start_packet(DisasContext *ctx)
     analyze_packet(ctx);
     for (int i = 0; i < TOTAL_PER_THREAD_REGS; ++i) {
         gen_helper_trace_load_reg(tcg_constant_i32(i), hex_gpr[i]);
+        gen_helper_trace_load_reg_new(tcg_constant_i32(i), hex_gpr[i]);
     }
     for (int i = 0; i < NUM_PREGS; ++i) {
         gen_helper_trace_load_pred(tcg_constant_i32(i), hex_pred[i]);
+        gen_helper_trace_load_pred_new(tcg_constant_i32(i), hex_pred[i]);
     }
 
     /*

--- a/target/hexagon/translate.c
+++ b/target/hexagon/translate.c
@@ -1059,6 +1059,7 @@ static void decode_and_translate_packet(CPUHexagonState *env, DisasContext *ctx)
         }
         gen_commit_packet(ctx);
         ctx->base.pc_next += pkt.encod_pkt_size_in_bytes;
+        gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_PC), tcg_constant_tl(ctx->base.pc_next));
         gen_helper_trace_endframe(cpu_env, tcg_constant_tl(pkt.pc), tcg_constant_i32(pkt.num_insns));
     } else {
         gen_exception_end_tb(ctx, HEX_EXCP_INVALID_PACKET);

--- a/target/hexagon/translate.c
+++ b/target/hexagon/translate.c
@@ -155,10 +155,10 @@ static void gen_end_tb(DisasContext *ctx)
 {
     Packet *pkt = ctx->pkt;
 
-    gen_helper_trace_endframe(cpu_env, tcg_constant_tl(pkt->pc), tcg_constant_i32(pkt->encod_pkt_size_in_bytes/4));
     gen_exec_counters(ctx);
 
     if (ctx->branch_cond != TCG_COND_NEVER) {
+        gen_helper_trace_endframe(cpu_env, tcg_constant_tl(pkt->pc), tcg_constant_i32(pkt->encod_pkt_size_in_bytes/4));
         if (ctx->branch_cond != TCG_COND_ALWAYS) {
             TCGLabel *skip = gen_new_label();
             tcg_gen_brcondi_tl(ctx->branch_cond, ctx->branch_taken, 0, skip);
@@ -177,10 +177,13 @@ static void gen_end_tb(DisasContext *ctx)
         TCGLabel *skip = gen_new_label();
         tcg_gen_brcondi_tl(TCG_COND_LEU, hex_gpr[HEX_REG_LC0], 1, skip);
         tcg_gen_subi_tl(hex_gpr[HEX_REG_LC0], hex_gpr[HEX_REG_LC0], 1);
+        gen_helper_trace_store_reg(tcg_constant_i32(HEX_REG_LC0), hex_gpr[HEX_REG_LC0]);
         gen_goto_tb(ctx, 0, ctx->base.tb->pc, true);
         gen_set_label(skip);
+        gen_helper_trace_endframe(cpu_env, tcg_constant_tl(pkt->pc), tcg_constant_i32(pkt->encod_pkt_size_in_bytes/4));
         gen_goto_tb(ctx, 1, ctx->next_PC, false);
     } else {
+        gen_helper_trace_endframe(cpu_env, tcg_constant_tl(pkt->pc), tcg_constant_i32(pkt->encod_pkt_size_in_bytes/4));
         tcg_gen_lookup_and_goto_ptr();
     }
 


### PR DESCRIPTION
Adds the trace support for the Hexagon architecture.

@ivg Please merge this into `tracewrap-8.1-hexagon` once everything looks good to you.
Also, no need to squash this. Since it is only for Hexagon anyways.