### PR TITLE
Fix some memory leaks in the BAP plugin

### DIFF
--- a/contrib/plugins/bap-tracing/frame_buffer.c
+++ b/contrib/plugins/bap-tracing/frame_buffer.c
@@ -257,10 +257,10 @@ OperandInfo *frame_init_reg_operand_info(const char *name, const uint8_t *value,
   return oi;
 }
 
-static OperandInfo *frame_init_mem_operand_info(uint64_t vaddr,
-                                                const uint8_t *mval,
-                                                size_t mval_bits,
-                                                bool is_store) {
+static OperandInfo *frame_init_mem_operand_info_take(uint64_t vaddr,
+                                                     uint8_t *mval,
+                                                     size_t mval_bits,
+                                                     bool is_store) {
   MemOperand *ro = g_new(MemOperand, 1);
   mem_operand__init(ro);
   ro->address = vaddr;
@@ -280,17 +280,20 @@ static OperandInfo *frame_init_mem_operand_info(uint64_t vaddr,
   oi->operand_info_specific = ois;
   oi->operand_usage = ou;
   oi->value.len = byte_width;
-  oi->value.data = g_malloc(oi->value.len);
-  memcpy(oi->value.data, mval, oi->value.len);
+  oi->value.data = mval;
 
   return oi;
 }
 
-bool frame_buffer_append_mem_info(FrameBuffer *fbuf, uint64_t vaddr,
-                                  const uint8_t *mval, size_t mval_bits,
-                                  bool is_store) {
+bool frame_buffer_append_mem_info_take(FrameBuffer *fbuf, uint64_t vaddr,
+                                       uint8_t *mval, size_t mval_bits,
+                                       bool is_store) {
   OperandInfo *oi =
-      frame_init_mem_operand_info(vaddr, mval, mval_bits, is_store);
+      frame_init_mem_operand_info_take(vaddr, mval, mval_bits, is_store);
   g_assert(oi);
-  return append_op_info(fbuf, oi);
+  if (!append_op_info(fbuf, oi)) {
+    free_operand(oi);
+    return false;
+  }
+  return true;
 }

--- a/contrib/plugins/bap-tracing/frame_buffer.h
+++ b/contrib/plugins/bap-tracing/frame_buffer.h
@@ -40,9 +40,14 @@ bool frame_buffer_new_frame_std(FrameBuffer *buf, unsigned int thread_id,
                                 uint64_t vaddr, const char *mode_id,
                                 uint8_t *bytes, size_t bytes_len);
 
-bool frame_buffer_append_mem_info(FrameBuffer *fbuf, uint64_t vaddr,
-                                  const uint8_t *mval, size_t mval_bits,
-                                  bool is_store);
+/**
+ * \brief Appends a memory operand to the open frame.
+ *
+ * Takes ownership of \p mval and frees it even if appending fails.
+ */
+bool frame_buffer_append_mem_info_take(FrameBuffer *fbuf, uint64_t vaddr,
+                                       uint8_t *mval, size_t mval_bits,
+                                       bool is_store);
 
 /**
  * \brief Appends the given operand info to the open frame.

--- a/contrib/plugins/bap-tracing/tracing.c
+++ b/contrib/plugins/bap-tracing/tracing.c
@@ -79,7 +79,8 @@ static void add_mem_op(VCPU *vcpu, unsigned int vcpu_index, FrameBuffer *fbuf,
   size_t mval_bits = mval_type_to_int(mval->type);
   uint8_t *buf = g_malloc(mval_bits / 8);
   mval_to_buf(mval, buf);
-  if (!frame_buffer_append_mem_info(fbuf, vaddr, buf, mval_bits, is_store)) {
+  if (!frame_buffer_append_mem_info_take(fbuf, vaddr, buf, mval_bits,
+                                         is_store)) {
     qemu_plugin_outs("Failed to append memory info\n");
   }
   return;
@@ -107,7 +108,7 @@ static void log_insn_mem_access(unsigned int vcpu_index,
 static void add_post_reg_state(VCPU *vcpu, unsigned int vcpu_index,
                                GArray *current_regs, FrameBuffer *fbuf) {
 
-  GByteArray *rdata = g_byte_array_new();
+  g_autoptr(GByteArray) rdata = g_byte_array_new();
   for (size_t i = 0; i < current_regs->len; ++i) {
     Register *prev_reg = vcpu->registers->pdata[i];
 
@@ -135,7 +136,7 @@ static void add_post_reg_state(VCPU *vcpu, unsigned int vcpu_index,
 
 static void add_pre_reg_state(VCPU *vcpu, unsigned int vcpu_index,
                               GArray *current_regs, FrameBuffer *fbuf) {
-  GByteArray *rdata = g_byte_array_new();
+  g_autoptr(GByteArray) rdata = g_byte_array_new();
   for (size_t i = 0; i < current_regs->len; ++i) {
     qemu_plugin_reg_descriptor *reg =
         &g_array_index(current_regs, qemu_plugin_reg_descriptor, i);
@@ -153,10 +154,9 @@ static void add_pre_reg_state(VCPU *vcpu, unsigned int vcpu_index,
 }
 
 static GPtrArray *registers_init(void) {
-  GArray *reg_list = qemu_plugin_get_registers();
+  g_autoptr(GArray) reg_list = qemu_plugin_get_registers();
 
   if (reg_list->len == 0) {
-    g_array_free(reg_list, false);
     return NULL;
   }
   GPtrArray *registers = g_ptr_array_new();
@@ -202,7 +202,7 @@ static void flush_all_frame_bufs(void) {
     FrameBuffer *fbuf = g_ptr_array_index(state.frame_buffer, i);
     VCPU *vcpu = g_ptr_array_index(state.vcpus, i);
     g_assert(vcpu);
-    GArray *current_regs = qemu_plugin_get_registers();
+    g_autoptr(GArray) current_regs = qemu_plugin_get_registers();
     g_assert(current_regs->len == vcpu->registers->len);
     add_post_reg_state(vcpu, i, current_regs, fbuf);
     frame_buffer_close_frame(fbuf);
@@ -240,7 +240,7 @@ static void log_insn_reg_access(unsigned int vcpu_index, void *udata) {
   FrameBuffer *fbuf = g_ptr_array_index(state.frame_buffer, vcpu_index);
   VCPU *vcpu = g_ptr_array_index(state.vcpus, vcpu_index);
   g_assert(vcpu);
-  GArray *current_regs = qemu_plugin_get_registers();
+  g_autoptr(GArray) current_regs = qemu_plugin_get_registers();
   g_assert(current_regs->len == vcpu->registers->len);
 
   if (!frame_buffer_is_empty(fbuf)) {


### PR DESCRIPTION
The plugin had several memory leaks which prevented it from running a relatively large, realistic workload. For example, a single run of the TCC compiler binary on a `int main() { return 0; }` made QEMU freeze the machine (8 GB of memory and 4 GB of swap) after about 10 minutes of runtime.

In one successful run of a smaller binary, up to 800 MB of memory can be wasted in total by program exit, according to Valgrind's MemCheck.

3 types of problems are fixed in this PR:

1- Most straightforwardly, the QEMU API [`qemu_plugin_get_registers` ](https://qemu.readthedocs.io/en/v10.0.3/devel/tcg-plugins.html#c.qemu_plugin_get_registers) is documented as returning caller-owned `GArray *`, there were 3 calls to it in the plugin with no free on the happy path, and the pointer wasn't stored anywhere. This was changed to use `g_autoptr` macro that uses a destructor-like (or defer-like) cleanup function on any return path from the function. This is also how it's used in the `execlog` [example plugin](https://github.com/qemu/qemu/blob/master/contrib/plugins/execlog.c).

2- Similarly, in `add_post_reg_state` and `add_pre_reg_state`, a `GByteArray` was used as a scratch buffer to read register state, it's local to the function and never stored anywhere. Thus, also freed with `g_autoptr`.

3- More interestingly, inside `log_insn_mem_access`, the function `add_mem_op` had two leaks:

3-a) `uint8_t *` buffer is allocated via `g_malloc` and given to `frame_buffer_append_mem_info` which takes it by a const pointer, that buffer is ultimately copied inside the latter function by `frame_init_mem_operand_info`, and the original is left without freeing.

3-b) The `OperandInfo` struct allocated by `frame_init_mem_operand_info` is returned to `frame_buffer_append_mem_info`, which calls `append_op_info`, which can fail if the frame is uninitialized. On failure, the `OperandInfo` struct is never used or stored anywhere so it should be freed, but neither `frame_buffer_append_mem_info` nor `add_mem_op` free it on failure. Both return or log an error and leave the orphan memory.

This was fixed by: 

- `frame_buffer_append_mem_info` and `frame_init_mem_operand_info` were renamed to have the suffix `take`, meaning they take ownership of the buffer they're passed directly. There is no need to free the original buffer in the function since its shallow copied to the `OperandInfo` struct and freed when it's freed.

- On failure, `frame_buffer_append_mem_info_take` frees the orphaned struct.

An inefficient alternative to `frame_buffer_append_mem_info_take` might have been to keep the copy semantics and free the temporary buffer in `add_mem_op` , but this is unnecessary anyway since it's never used elsewhere in the function, and `frame_buffer_append_mem_info`  has no other callers that would need updating.

After those changes, the TCC run was successful, producing 25 GB output file. Only 2-3 MB of memory was leaked on the smaller run according to valgrind, most of the leaks either coming from QEMU proper (`main.c`, perhaps some commandline arguments or global lifetime data), and some plugin data is leaked by being still reachable at program exit, probably due to the plugin exit callback being commented out and not being called to flush the final frames.